### PR TITLE
代码重构

### DIFF
--- a/src/main/java/com/lc/nlp4han/constituent/BracketExpUtil.java
+++ b/src/main/java/com/lc/nlp4han/constituent/BracketExpUtil.java
@@ -65,7 +65,7 @@ public class BracketExpUtil {
 	 * @param bracketStr 括号表达式
 	 * @return
 	 */
-	private static List<String> stringToList(String bracketStr){
+	public static List<String> stringToList(String bracketStr){
 		List<String> parts = new ArrayList<String>();
         for (int index = 0; index < bracketStr.length(); ++index) {
             if (bracketStr.charAt(index) == '(' || bracketStr.charAt(index) == ')' || bracketStr.charAt(index) == ' ') {

--- a/src/main/java/com/lc/nlp4han/constituent/ChunkTreeCombineUtil.java
+++ b/src/main/java/com/lc/nlp4han/constituent/ChunkTreeCombineUtil.java
@@ -1,0 +1,101 @@
+package com.lc.nlp4han.constituent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lc.nlp4han.constituent.maxent.AbstractGenerateHeadWords;
+import com.lc.nlp4han.constituent.maxent.HeadWordsRuleSet;
+
+/**
+ * 合并chunk子树
+ * @author 王馨苇
+ *
+ */
+public class ChunkTreeCombineUtil {
+
+	/**
+	 * 对CHUNK子树进行合并，就是合并start和join部分
+	 * 说明：用于合并的chunk子树有头结点，合并的过程中要重新生成头结点，保持树依旧是带头结点的树
+	 * @param subTree 第二部CHUNK得到的若干棵子树
+	 * @return
+	 */
+	public static List<HeadTreeNode> combineToHeadTree(List<HeadTreeNode> subTree,AbstractGenerateHeadWords aghw){
+		List<HeadTreeNode> combineChunk = new ArrayList<HeadTreeNode>();
+		//遍历所有子树
+		for (int i = 0; i < subTree.size(); i++) {
+			//当前子树的根节点是start标记的
+			if(subTree.get(i).getNodeName().split("_")[0].equals("start")){
+				//只要是start标记的就去掉root中的start，生成一颗新的子树，
+				//因为有些结构，如（NP(NN chairman)），只有start没有join部分，
+				//所以遇到start就生成新的子树
+				HeadTreeNode node = new HeadTreeNode(subTree.get(i).getNodeName().split("_")[1]);
+				node.addChild(subTree.get(i).getFirstChild());
+				node.setHeadWords(aghw.extractHeadWords(node, HeadWordsRuleSet.getNormalRuleSet(), HeadWordsRuleSet.getSpecialRuleSet()).split("_")[0]);
+				node.setHeadWordsPos(aghw.extractHeadWords(node, HeadWordsRuleSet.getNormalRuleSet(), HeadWordsRuleSet.getSpecialRuleSet()).split("_")[1]);
+				subTree.get(i).getFirstChild().setParent(node);
+				for (int j = i+1; j < subTree.size(); j++) {
+					//判断start后是否有join如果有，就和之前的start合并
+					if(subTree.get(j).getNodeName().split("_")[0].equals("join")){
+						node.addChild(subTree.get(j).getFirstChild());
+						subTree.get(j).getFirstChild().setParent(node);
+					}else if(subTree.get(j).getNodeName().split("_")[0].equals("start") ||
+							subTree.get(j).getNodeName().split("_")[0].equals("other")){
+						break;
+					}
+					node.setHeadWords(aghw.extractHeadWords(node, HeadWordsRuleSet.getNormalRuleSet(), HeadWordsRuleSet.getSpecialRuleSet()).split("_")[0]);
+					node.setHeadWordsPos(aghw.extractHeadWords(node, HeadWordsRuleSet.getNormalRuleSet(), HeadWordsRuleSet.getSpecialRuleSet()).split("_")[1]);
+				}
+				//将一颗合并过的完整子树加入列表
+				combineChunk.add(node);
+				//标记为other的，去掉other
+			}else if(subTree.get(i).getNodeName().equals("other")){
+				subTree.get(i).getFirstChild().setParent(null);
+				subTree.get(i).getFirstChild().setHeadWords(subTree.get(i).getChildren().get(0).getHeadWords());
+				subTree.get(i).getFirstChild().setHeadWordsPos(subTree.get(i).getChildren().get(0).getHeadWordsPos());
+				combineChunk.add(subTree.get(i).getFirstChild());
+			}
+		}
+		return combineChunk;
+	}
+	
+	/**
+	 * chunk步得到的结果进行合并
+	 * 说明：用于合并的chunk子树没有头结点，合并之后也没有头结点
+	 * @param chunktree chunk子树
+	 * @return
+	 */
+	public static List<TreeNode> combineToTree(List<TreeNode> chunktree){
+		//第三部合并
+		//需要为合并后的结点设置头结点
+		List<TreeNode> combine = new ArrayList<TreeNode>();
+		//遍历所有子树
+		for (int i = 0; i < chunktree.size(); i++) {		
+			//当前子树的根节点是start标记的		
+			if(chunktree.get(i).getNodeName().split("_")[0].equals("start")){			
+				//只要是start标记的就去掉root中的start，生成一颗新的子树，		
+				//因为有些结构，如（NP(NN chairman)），只有start没有join部分，
+				//所以遇到start就生成新的子树
+				TreeNode node = new TreeNode(chunktree.get(i).getNodeName().split("_")[1]);			
+				node.addChild(chunktree.get(i).getFirstChild());	
+				chunktree.get(i).getChildren().get(0).setParent(node);			
+				for (int j = i+1; j < chunktree.size(); j++) {			
+					//判断start后是否有join如果有，就和之前的start合并				
+					if(chunktree.get(j).getNodeName().split("_")[0].equals("join")){					
+						node.addChild(chunktree.get(j).getFirstChild());					
+						chunktree.get(j).getFirstChild().setParent(node);				
+					}else if(chunktree.get(j).getNodeName().split("_")[0].equals("start") ||					
+							chunktree.get(j).getNodeName().split("_")[0].equals("other")){				
+						break;				
+					}			
+				}
+				//将一颗合并过的完整子树加入列表
+				combine.add(node);
+				//标记为other的，去掉other		 
+			}else if(chunktree.get(i).getNodeName().equals("other")){										
+				chunktree.get(i).getFirstChild().setParent(null);	
+				combine.add(chunktree.get(i).getFirstChild());		
+			}
+		}
+		return combine;
+	}
+}

--- a/src/main/java/com/lc/nlp4han/constituent/ConstituentTree.java
+++ b/src/main/java/com/lc/nlp4han/constituent/ConstituentTree.java
@@ -1,7 +1,7 @@
 package com.lc.nlp4han.constituent;
 
 /**
- * 成分树
+ * 成分树结构设计
  * @author 王馨苇
  *
  */
@@ -21,6 +21,4 @@ public class ConstituentTree {
 	public String toString() {
 		return root.toString();
 	}
-	
-	
 }

--- a/src/main/java/com/lc/nlp4han/constituent/PlainTextByTreeStream.java
+++ b/src/main/java/com/lc/nlp4han/constituent/PlainTextByTreeStream.java
@@ -11,7 +11,8 @@ import com.lc.nlp4han.ml.util.InputStreamFactory;
 import com.lc.nlp4han.ml.util.ObjectStream;
 
 /**
- * 实现ObjectStream，完成其中的read操作，每次读取一棵成分树的括号表达式字符串
+ * 从训练语料中读取完整的树
+ * 说明：每次读取一颗完整的树是根据括号的匹配情况来判断
  * 
  * @author 刘小峰
  * @author 王馨苇

--- a/src/main/java/com/lc/nlp4han/constituent/TreeNode.java
+++ b/src/main/java/com/lc/nlp4han/constituent/TreeNode.java
@@ -23,7 +23,11 @@ public class TreeNode implements Cloneable{
 	//当前父节点下的第几颗子树
 	private int index;
 	
-	//标记当前节点是否是空节点或者标记当前节点是否被剪枝
+	/**
+	 * 在句法分析的去除空节点的预处理步骤中：用来标记当前节点是否是空节点
+	 * 在语义分析的去除空节点的预处理步骤中：用来标记当前节点是否是空节点
+	 * 在语义分析的剪枝的预处理步骤中：用来标记当前节点是否已被剪枝
+	 */
 	private boolean flag;
 	
 	private int wordindex;

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/AbstractGenerateHeadWords.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/AbstractGenerateHeadWords.java
@@ -6,18 +6,18 @@ import java.util.List;
 import com.lc.nlp4han.constituent.HeadTreeNode;
 
 /**
- * 生成头结点的模板类【模板设计模式】
+ * 生成头结点的抽象模板类
  * @author 王馨苇
  *
  */
-public abstract class AbsractGenerateHeadWords<T extends HeadTreeNode>{
+public abstract class AbstractGenerateHeadWords{
 	
 	/**
 	 * 为并列结构生成头结点
 	 * @param node 子节点带头结点，父节点不带头结点的树
 	 * @return
 	 */
-	public abstract String generateHeadWordsForCordinator(T node);
+	protected abstract String generateHeadWordsForCordinator(HeadTreeNode node);
 
 	/**
 	 * 为特殊规则生成头结点
@@ -25,7 +25,7 @@ public abstract class AbsractGenerateHeadWords<T extends HeadTreeNode>{
 	 * @param specialRules 生成头结点的特殊规则
 	 * @return
 	 */
-	public abstract String generateHeadWordsForSpecialRules(T node,HashMap<String,List<Rule>> specialRules);
+	protected abstract String generateHeadWordsForSpecialRules(HeadTreeNode node,HashMap<String,List<Rule>> specialRules);
 	
 	/**
 	 * 为一般规则生成头结点
@@ -33,16 +33,16 @@ public abstract class AbsractGenerateHeadWords<T extends HeadTreeNode>{
 	 * @param normalRules 生成头结点的一般规则
 	 * @return
 	 */
-	public abstract String generateHeadWordsForNormalRules(T node,HashMap<String,Rule> normalRules);
+	protected abstract String generateHeadWordsForNormalRules(HeadTreeNode node,HashMap<String,Rule> normalRules);
 
 	/**
-	 * 提取头结点【自底向上生成头结点】
+	 * 合并生成头结点的所有方法，提取头结点
 	 * @param node 子节点带头结点，父节点不带头结点的树
 	 * @param normalRules 生成头结点的一般规则
 	 * @param specialRules 生成头结点的特殊规则
 	 * @return
 	 */
-	public String extractHeadWords(T node, HashMap<String,Rule> normalRules,HashMap<String,List<Rule>> specialRules){
+	public String extractHeadWords(HeadTreeNode node, HashMap<String,Rule> normalRules,HashMap<String,List<Rule>> specialRules){
 		String headWords = null;
 		headWords = generateHeadWordsForCordinator(node);
 		

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/ConcreteGenerateHeadWords.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/ConcreteGenerateHeadWords.java
@@ -6,11 +6,12 @@ import java.util.List;
 import com.lc.nlp4han.constituent.HeadTreeNode;
 
 /**
- * 生成头结点
+ * 具体的生成头结点的实现类
+ * 参考：Collins 1999论文
  * @author 王馨苇
  *
  */
-public class ConcreteGenerateHeadWords extends AbsractGenerateHeadWords<HeadTreeNode>{
+public class ConcreteGenerateHeadWords extends AbstractGenerateHeadWords{
 
 	/**
 	 * 为并列结构生成头结点

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/Rule.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/Rule.java
@@ -3,7 +3,8 @@ package com.lc.nlp4han.constituent.maxent;
 import java.util.List;
 
 /**
- * 存储规则集的右部和方向
+ * 规则的结构设计类
+ * 说明：该规则包含规则的右部和遍历的方向
  * @author 王馨苇
  *
  */

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysis.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysis.java
@@ -55,12 +55,14 @@ public interface SyntacticAnalysis<T extends TreeNode> {
 	
 	/**
 	 * 得到最好的K个句法树
+	 * @param k 最好的K个结果
 	 * @param chunkTree chunk子树序列
 	 * @return
 	 */
 	ConstituentTree[] syntacticTree(int k,List<T> chunkTree);
 	/**
 	 * 得到最好的K个句法树
+	 * @param k 最好的K个结果
 	 * @param words 词语
 	 * @param poses 词性标记
 	 * @param chunkTag chunk标记
@@ -69,6 +71,7 @@ public interface SyntacticAnalysis<T extends TreeNode> {
 	ConstituentTree[] syntacticTree(int k,String[] words,String[] poses,String[] chunkTag);
 	/**
 	 * 得到最好的K个句法树
+	 * @param k 最好的K个结果
 	 * @param sentence 由词语词性标记和chunk标记组成的句子
 	 * @return
 	 */

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisBeamSearch.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisBeamSearch.java
@@ -16,7 +16,7 @@ import com.lc.nlp4han.ml.util.Cache;
  */
 public class SyntacticAnalysisBeamSearch implements SyntacticAnalysisSequenceClassificationModel<HeadTreeNode>{
 
-	private AbsractGenerateHeadWords<HeadTreeNode> aghw = new ConcreteGenerateHeadWords(); 
+	private AbstractGenerateHeadWords aghw ; 
 	public static final String BEAM_SIZE_PARAMETER = "BeamSize";
 	private static final Object[] EMPTY_ADDITIONAL_CONTEXT = new Object[0];
 	protected int size;
@@ -28,12 +28,12 @@ public class SyntacticAnalysisBeamSearch implements SyntacticAnalysisSequenceCla
 	private double[] chunkprobs;
 	private Cache<String[], double[]> contextsCache;
 
-	public SyntacticAnalysisBeamSearch(int size, ClassificationModel buildmodel, ClassificationModel checkmodel) {
-		this(size, buildmodel, checkmodel, 0);
+	public SyntacticAnalysisBeamSearch(int size, ClassificationModel buildmodel, ClassificationModel checkmodel, AbstractGenerateHeadWords aghw) {
+		this(size, buildmodel, checkmodel, 0, aghw);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public SyntacticAnalysisBeamSearch(int size, ClassificationModel buildmodel, ClassificationModel checkmodel, int cacheSize) {
+	public SyntacticAnalysisBeamSearch(int size, ClassificationModel buildmodel, ClassificationModel checkmodel, int cacheSize, AbstractGenerateHeadWords aghw) {
 		this.size = size;
 		this.buildmodel = buildmodel;
 		this.checkmodel = checkmodel;
@@ -42,6 +42,7 @@ public class SyntacticAnalysisBeamSearch implements SyntacticAnalysisSequenceCla
 		}
 
 		this.buildprobs = new double[buildmodel.getNumOutcomes()];
+		this.aghw = aghw;
 	}
 	
 	public SyntacticAnalysisBeamSearch(int size, ClassificationModel chunkmodel) {

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisEvaluatorForChina.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisEvaluatorForChina.java
@@ -23,18 +23,21 @@ public class SyntacticAnalysisEvaluatorForChina extends Evaluator<SyntacticAnaly
 	private SyntacticAnalysisMEForChunk chunktagger;
 	private SyntacticAnalysisMEForBuildAndCheck buildAndChecktagger;
 	private SyntacticAnalysisMeasure measure;
+	private AbstractGenerateHeadWords aghw;
 	
-	public SyntacticAnalysisEvaluatorForChina(WordSegAndPosME postagger,SyntacticAnalysisMEForChunk chunktagger,SyntacticAnalysisMEForBuildAndCheck buildAndChecktagger) {
+	public SyntacticAnalysisEvaluatorForChina(WordSegAndPosME postagger,SyntacticAnalysisMEForChunk chunktagger,SyntacticAnalysisMEForBuildAndCheck buildAndChecktagger, AbstractGenerateHeadWords aghw) {
 		this.postagger = postagger;
 		this.chunktagger = chunktagger;
 		this.buildAndChecktagger = buildAndChecktagger;
+		this.aghw = aghw;
 	}
 	
-	public SyntacticAnalysisEvaluatorForChina(WordSegAndPosME postagger,SyntacticAnalysisMEForChunk chunktagger,SyntacticAnalysisMEForBuildAndCheck buildAndChecktagger,SyntacticAnalysisEvaluateMonitor... evaluateMonitors) {
+	public SyntacticAnalysisEvaluatorForChina(WordSegAndPosME postagger,SyntacticAnalysisMEForChunk chunktagger,SyntacticAnalysisMEForBuildAndCheck buildAndChecktagger, AbstractGenerateHeadWords aghw,SyntacticAnalysisEvaluateMonitor... evaluateMonitors) {
 		super(evaluateMonitors);
 		this.postagger = postagger;
 		this.chunktagger = chunktagger;
 		this.buildAndChecktagger = buildAndChecktagger;
+		this.aghw = aghw;
 	}
 	
 	/**
@@ -63,9 +66,8 @@ public class SyntacticAnalysisEvaluatorForChina extends Evaluator<SyntacticAnaly
 			try {
 				List<String> words = sample.getWords();
 				List<String> actionsRef = sample.getActions();
-				ActionsToTree att = new ActionsToTree();
 				//参考样本没有保存完整的一棵树，需要将动作序列转成一颗完整的树
-				TreeNode treeRef = att.actionsToTree(words, actionsRef);
+				TreeNode treeRef = ActionsToTree.actionsToTree(words, actionsRef);
 				String[][] poses = postagger.tag(5, words.toArray(new String[words.size()]));
 				List<List<HeadTreeNode>> posTree = toPosTree(words.toArray(new String[words.size()]), poses);
 				List<List<HeadTreeNode>> chunkTree = chunktagger.tagKChunk(20, posTree, null);	
@@ -74,8 +76,7 @@ public class SyntacticAnalysisEvaluatorForChina extends Evaluator<SyntacticAnaly
 					samplePre = new SyntacticAnalysisSample<HeadTreeNode>(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
 					measure.countNodeDecodeTrees(treePre);
 				}else{
-					HeadTreeToActions tta = new HeadTreeToActions();
-					samplePre = tta.treeToAction(treePre);
+					samplePre = HeadTreeToActions.headTreeToAction(treePre,aghw);
 					measure.update(treeRef, treePre);
 				}	
 			} catch(Exception e){

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisMeasure.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisMeasure.java
@@ -40,10 +40,8 @@ public class SyntacticAnalysisMeasure {
 	 * @throws CloneNotSupportedException 
 	 */
 	public void update(TreeNode treeRef,TreeNode treePre) throws CloneNotSupportedException{
-		TreeToEvalStructure ttn1 = new TreeToEvalStructure();
-		List<EvalStructure> etRef = ttn1.getNonterminalAndSpan(treeRef);
-		TreeToEvalStructure ttn2 = new TreeToEvalStructure();
-		List<EvalStructure> etPre = ttn2.getNonterminalAndSpan(treePre);
+		List<EvalStructure> etRef = TreeToEvalStructure.getNonterminalAndSpan(treeRef);
+		List<EvalStructure> etPre = TreeToEvalStructure.getNonterminalAndSpan(treePre);
 		int trueSentencetemp = 0;	
 		int CBs_2_temp = 0;
 		for (int j = 0; j < etPre.size(); j++) {

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSample.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSample.java
@@ -137,8 +137,7 @@ public class SyntacticAnalysisSample<T extends TreeNode> {
 	 * @return
 	 */
 	public static TreeNode toSample(List<String> words ,List<String> actions){
-		ActionsToTree att = new ActionsToTree();
-		TreeNode tree = att.actionsToTree(words, actions);
+		TreeNode tree = ActionsToTree.actionsToTree(words, actions);
 		return tree;
 	}
 	

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventForBuild.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventForBuild.java
@@ -45,9 +45,7 @@ public class SyntacticAnalysisSampleEventForBuild extends AbstractEventStream<Sy
 	/**
 	 * 事件生成
 	 * @param words 词语序列
-	 * @param posTree pos得到的子树
-	 * @param chunkTree chunk得到的子树
-	 * @param buildAndCheck buildAndCheck得到的子树
+	 * @param buildAndCheckTree buildAndCheck得到的子树
 	 * @param actions 动作序列
 	 * @param ac
 	 * @return

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventForCheck.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventForCheck.java
@@ -44,9 +44,7 @@ public class SyntacticAnalysisSampleEventForCheck extends AbstractEventStream<Sy
 	/**
 	 * 事件生成
 	 * @param words 词语序列
-	 * @param posTree pos得到的子树
-	 * @param chunkTree chunk得到的子树
-	 * @param buildAndCheck buildAndCheck得到的子树
+	 * @param buildAndCheckTree buildAndCheck得到的子树
 	 * @param actions 动作序列
 	 * @param ac
 	 * @return

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventForChunk.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventForChunk.java
@@ -10,7 +10,7 @@ import com.lc.nlp4han.ml.util.AbstractEventStream;
 import com.lc.nlp4han.ml.util.ObjectStream;
 
 /**
- * 为check模型生成事件
+ * 为chunk模型生成事件
  * @author 王馨苇
  *
  */
@@ -44,9 +44,7 @@ public class SyntacticAnalysisSampleEventForChunk extends AbstractEventStream<Sy
 	/**
 	 * 事件生成
 	 * @param words 词语序列
-	 * @param posTree pos得到的子树
 	 * @param chunkTree chunk得到的子树
-	 * @param buildAndCheck buildAndCheck得到的子树
 	 * @param actions 动作序列
 	 * @param ac
 	 * @return

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleStream.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleStream.java
@@ -21,12 +21,14 @@ public class SyntacticAnalysisSampleStream extends FilterObjectStream<String,Syn
 
 	
 	private Logger logger = Logger.getLogger(SyntacticAnalysisSampleStream.class.getName());
+	private AbstractGenerateHeadWords aghw ;
 	/**
 	 * 构造
 	 * @param samples 样本流
 	 */
-	public SyntacticAnalysisSampleStream(ObjectStream<String> samples) {
+	public SyntacticAnalysisSampleStream(ObjectStream<String> samples, AbstractGenerateHeadWords aghw) {
 		super(samples);
+		this.aghw = aghw;
 	}
 
 	/**
@@ -37,15 +39,12 @@ public class SyntacticAnalysisSampleStream extends FilterObjectStream<String,Syn
 	public SyntacticAnalysisSample<HeadTreeNode> read() throws IOException {
 		String sentence = samples.read();	
 		SyntacticAnalysisSample<HeadTreeNode> sample = null;
-		BracketExpUtil pgt = new BracketExpUtil();
-		TreeToHeadTree ttht = new TreeToHeadTree();
-		HeadTreeToActions tta = new HeadTreeToActions();
 		if(sentence != null){
 			if(sentence.compareTo("") != 0){
 				try{
-					TreeNode tree = pgt.generateTree(sentence);
-					HeadTreeNode headtree = ttht.treeToHeadTree(tree);
-					sample = tta.treeToAction(headtree);
+					TreeNode tree = BracketExpUtil.generateTree(sentence);
+					HeadTreeNode headtree = TreeToHeadTree.treeToHeadTree(tree,aghw);
+					sample = HeadTreeToActions.headTreeToAction(headtree,aghw);
 				}catch(Exception e){
 					if (logger.isLoggable(Level.WARNING)) {						
 	                    logger.warning("Error during parsing, ignoring sentence: " + sentence);

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSequenceClassificationModel.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSequenceClassificationModel.java
@@ -6,7 +6,7 @@ import com.lc.nlp4han.constituent.TreeNode;
 
 
 /**
- * 得到结果序列的接口
+ * 句法分析序列分类模型
  * @author 王馨苇
  *
  */

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSequenceForBuildAndCheck.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSequenceForBuildAndCheck.java
@@ -5,7 +5,13 @@ import java.util.List;
 
 import com.lc.nlp4han.constituent.TreeNode;
 
-
+/**
+ * buildAndCheck步的序列
+ * 说明：序列中的每一个元素都是该类的对象，包含下述所有信息
+ * @author 王馨苇
+ *
+ * @param <T> 树中节点的类型
+ */
 public class SyntacticAnalysisSequenceForBuildAndCheck<T extends TreeNode> implements Comparable<SyntacticAnalysisSequenceForBuildAndCheck<T>> {
 	private double score;
 	private double scorecheck;

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSequenceForChunk.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSequenceForChunk.java
@@ -4,6 +4,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Chunk步的序列
+ * 说明：序列中的每一个元素都是该类的对象，包含下述所有信息
+ * @author 王馨苇
+ *
+ */
 public class SyntacticAnalysisSequenceForChunk implements Comparable<SyntacticAnalysisSequenceForChunk> {
 	private double score;
 	private List<String> outcomes;

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisTrainerTool.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisTrainerTool.java
@@ -8,7 +8,7 @@ import com.lc.nlp4han.ml.util.TrainingParameters;
 
 
 /**
- * 句法分析训练类
+ * 句法分析训练模型运行类
  * @author 王馨苇
  *
  */
@@ -16,7 +16,7 @@ public class SyntacticAnalysisTrainerTool {
 
 	private static void usage(){
 		System.out.println(SyntacticAnalysisTrainerTool.class.getName()+"-data <corpusFile> -chunkmodel <chunkmodelFile> -buildmodel <buildmodelFile> -checkmodel <checkmodelFile> -type <algorithom>"
-				+ "-encoding"+"[-cutoff <num>] [-iters <num>]");
+				+ "-encoding <encoding>"+"[-cutoff <num>] [-iters <num>]");
 	}
 	
 	public static void main(String[] args) throws IOException {
@@ -77,13 +77,15 @@ public class SyntacticAnalysisTrainerTool {
         }
         
         SyntacticAnalysisContextGenerator<HeadTreeNode> contextGen = new SyntacticAnalysisContextGeneratorConf();
+        System.out.println(contextGen);
         TrainingParameters params = TrainingParameters.defaultParams();
         params.put(TrainingParameters.CUTOFF_PARAM, Integer.toString(cutoff));
         params.put(TrainingParameters.ITERATIONS_PARAM, Integer.toString(iters));
         params.put(TrainingParameters.ALGORITHM_PARAM, type.toUpperCase());
         
-        SyntacticAnalysisMEForChunk.train(corpusFile, chunkmodelFile,params, contextGen, encoding);
-		SyntacticAnalysisMEForBuildAndCheck.trainForBuild(corpusFile, buildmodelFile, params, contextGen, encoding);
-		SyntacticAnalysisMEForBuildAndCheck.trainForCheck(corpusFile, checkmodelFile, params, contextGen, encoding);
+        AbstractGenerateHeadWords aghw = new ConcreteGenerateHeadWords();
+        SyntacticAnalysisMEForChunk.train(corpusFile, chunkmodelFile,params, contextGen, encoding, aghw);
+		SyntacticAnalysisMEForBuildAndCheck.trainForBuild(corpusFile, buildmodelFile, params, contextGen, encoding, aghw);
+		SyntacticAnalysisMEForBuildAndCheck.trainForCheck(corpusFile, checkmodelFile, params, contextGen, encoding, aghw);
 	}
 }

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/TreePreTreatment.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/TreePreTreatment.java
@@ -13,7 +13,8 @@ import com.lc.nlp4han.constituent.TreeNode;
 import com.lc.nlp4han.ml.util.FileInputStreamFactory;
 
 /**
- * 训练语料中树的初始化处理
+ * 句法树的初始化处理
+ * 说明：去除句法树中的空节点，去除节点命名中的功能标记
  * @author 王馨苇
  *
  */
@@ -40,18 +41,17 @@ public class TreePreTreatment{
 	 */
 	public static void pretreatment(String frompath,String topath) throws UnsupportedOperationException, FileNotFoundException, IOException{
 		//读取一颗树
-		PlainTextByTreeStream lineStream = null;
-		BracketExpUtil pgt = new BracketExpUtil();		
+		PlainTextByTreeStream lineStream = null;	
 		//创建输出流
 		BufferedWriter bw = new BufferedWriter(new FileWriter(new File(topath)));
 		lineStream = new PlainTextByTreeStream(new FileInputStreamFactory(new File(frompath)), "utf8");
 		String tree = "";
 		while((tree = lineStream.read()) != ""){
-			TreeNode node = pgt.generateTree(tree);
+			TreeNode node = BracketExpUtil.generateTree(tree);
 			//对树进行遍历
 			travelTree(node);	
 			String newTreeStr = node.toNoNoneSample();
-			TreeNode newTree = pgt.generateTree("("+newTreeStr+")");
+			TreeNode newTree = BracketExpUtil.generateTree("("+newTreeStr+")");
 			bw.write("("+TreeNode.printTree(newTree, 1)+")");
 			bw.newLine();
 		}

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/TreePreTreatmentTool.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/TreePreTreatmentTool.java
@@ -4,11 +4,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /**
- * 树预处理运行工具类
+ * 句法树预处理运行类
  * @author 王馨苇
  *
  */
-public class TreePreTreatmentTools {
+public class TreePreTreatmentTool {
 
 	public static void main(String[] args) throws UnsupportedOperationException, FileNotFoundException, IOException {
 		String cmd = args[0];

--- a/src/main/java/com/lc/nlp4han/constituent/maxent/TreeToHeadTree.java
+++ b/src/main/java/com/lc/nlp4han/constituent/maxent/TreeToHeadTree.java
@@ -1,30 +1,29 @@
 package com.lc.nlp4han.constituent.maxent;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
+import com.lc.nlp4han.constituent.BracketExpUtil;
 import com.lc.nlp4han.constituent.HeadTreeNode;
 import com.lc.nlp4han.constituent.TreeNode;
 
 /**
- * 
+ * 将不含头结点的句法树，转换成包含头结点的句法树
  * @author 王馨苇
  *
  */
 public class TreeToHeadTree {
-
-	private AbsractGenerateHeadWords<HeadTreeNode> aghw = new ConcreteGenerateHeadWords(); 
+	
 	/**
 	 * 将一颗无头结点的树转成带头结点的树
 	 * @param treeNode
 	 * @return
 	 */
-	public HeadTreeNode treeToHeadTree(TreeNode treeNode){
+	public static HeadTreeNode treeToHeadTree(TreeNode treeNode, AbstractGenerateHeadWords aghw){
 		String treeStr = "("+treeNode.toNoNoneSample()+")";
-		treeStr = format(treeStr);
+		treeStr = BracketExpUtil.format(treeStr);
 		int indexTree;//记录当前是第几颗子树
-		List<String> parts = stringToList(treeStr); 
+		List<String> parts = BracketExpUtil.stringToList(treeStr); 
         Stack<HeadTreeNode> tree = new Stack<HeadTreeNode>();
         for (int i = 0; i < parts.size(); i++) {
 			if(!parts.get(i).equals(")") && !parts.get(i).equals(" ")){
@@ -72,50 +71,5 @@ public class TreeToHeadTree {
 		}
         HeadTreeNode treeStruct = tree.pop();
         return treeStruct;
-	}
-	
-	/**
-	 * 将括号表达式去掉空格转成列表的形式
-	 * @param treeStr 括号表达式
-	 * @return
-	 */
-	public List<String> stringToList(String treeStr){
-
-		List<String> parts = new ArrayList<String>();
-        for (int index = 0; index < treeStr.length(); ++index) {
-            if (treeStr.charAt(index) == '(' || treeStr.charAt(index) == ')' || treeStr.charAt(index) == ' ') {
-                parts.add(Character.toString(treeStr.charAt(index)));
-            } else {
-                for (int i = index + 1; i < treeStr.length(); ++i) {
-                    if (treeStr.charAt(i) == '(' || treeStr.charAt(i) == ')' || treeStr.charAt(i) == ' ') {
-                        parts.add(treeStr.substring(index, i));
-                        index = i - 1;
-                        break;
-                    }
-                }
-            }
-        }
-        return parts;
-	}
-	
-	/**
-	 * 格式化为形如：(A(B1(C1 d1)(C2 d2))(B2 d3)) 的括号表达式。叶子及其父节点用一个空格分割，其他字符紧密相连。
-	 * @param tree 从训练语料拼接出的一棵树
-	 */
-	public String format(String tree){
-		//去除最外围的括号
-        tree = tree.substring(1, tree.length() - 1).trim();
-        //所有空白符替换成一位空格
-        tree = tree.replaceAll("\\s+", " ");
-        //去掉 ( 和 ) 前的空格
-        String newTree = "";
-        for (int c = 0; c < tree.length(); ++c) {
-            if (tree.charAt(c) == ' ' && (tree.charAt(c + 1) == '(' || tree.charAt(c + 1) == ')')) {
-                continue;
-            } else {
-                newTree = newTree + (tree.charAt(c));
-            }
-        }
-        return newTree;
 	}
 }

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/GenerateHeadWordsTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/GenerateHeadWordsTest.java
@@ -2,7 +2,6 @@ package com.lc.nlp4han.constituent.maxent;
 
 import static org.junit.Assert.*;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.lc.nlp4han.constituent.BracketExpUtil;
@@ -15,34 +14,23 @@ import com.lc.nlp4han.constituent.TreeNode;
  *
  */
 public class GenerateHeadWordsTest {
-
-	private BracketExpUtil pgt;
-	private TreeToHeadTree ttht;
-	private TreeNode tree1;
-	private HeadTreeNode headTree1;
-	private String result1;
-	private TreeNode tree2;
-	private HeadTreeNode headTree2;
-	private String result2;
-	
-	@Before
-	public void setUP() throws CloneNotSupportedException{
-		pgt = new BracketExpUtil();
-		ttht = new TreeToHeadTree();
-		tree1 = pgt.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
-		headTree1 = ttht.treeToHeadTree(tree1);
-		result1 = "(S{saw[VBD]}(NP{I[PRP]}(PRP{I[PRP]} I[0]))(VP{saw[VBD]}(VP{saw[VBD]}(VBD{saw[VBD]} saw[1])(NP{man[NN]}(DT{the[DT]} the[2])"
-				+ "(NN{man[NN]} man[3])))(PP{with[IN]}(IN{with[IN]} with[4])(NP{telescope[NN]}(DT{the[DT]} the[5])(NN{telescope[NN]} telescope[6])))))";
-		tree2 = pgt.generateTree("((S(NP(EX There))(VP(VBZ is)(NP(DT no)(NN asbestos))(PP(IN in)(NP(PRP$ our)(NNS products)))(ADVP (RB now)))(. .)('' '') ))");
-		headTree2 = ttht.treeToHeadTree(tree2);
-		result2 = "(S{is[VBZ]}(NP{There[EX]}(EX{There[EX]} There[0]))(VP{is[VBZ]}(VBZ{is[VBZ]} is[1])"
-				+ "(NP{asbestos[NN]}(DT{no[DT]} no[2])(NN{asbestos[NN]} asbestos[3]))(PP{in[IN]}"
-				+ "(IN{in[IN]} in[4])(NP{products[NNS]}(PRP${our[PRP$]} our[5])(NNS{products[NNS]} products[6])))"
-				+ "(ADVP{now[RB]}(RB{now[RB]} now[7])))(.{.[.]} .[8])(''{''['']} ''[9]))";
-	}
 	
 	@Test
 	public void testGenerateHeadWords(){
+
+		AbstractGenerateHeadWords aghw = new ConcreteGenerateHeadWords();	
+		TreeNode tree1 = BracketExpUtil.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
+		HeadTreeNode headTree1 = TreeToHeadTree.treeToHeadTree(tree1,aghw);
+		String result1 = "(S{saw[VBD]}(NP{I[PRP]}(PRP{I[PRP]} I[0]))(VP{saw[VBD]}(VP{saw[VBD]}(VBD{saw[VBD]} saw[1])(NP{man[NN]}(DT{the[DT]} the[2])"
+				+ "(NN{man[NN]} man[3])))(PP{with[IN]}(IN{with[IN]} with[4])(NP{telescope[NN]}(DT{the[DT]} the[5])(NN{telescope[NN]} telescope[6])))))";
+		
+		TreeNode tree2 = BracketExpUtil.generateTree("((S(NP(EX There))(VP(VBZ is)(NP(DT no)(NN asbestos))(PP(IN in)(NP(PRP$ our)(NNS products)))(ADVP (RB now)))(. .)('' '') ))");
+		HeadTreeNode headTree2 = TreeToHeadTree.treeToHeadTree(tree2,aghw);
+		String result2 = "(S{is[VBZ]}(NP{There[EX]}(EX{There[EX]} There[0]))(VP{is[VBZ]}(VBZ{is[VBZ]} is[1])"
+				+ "(NP{asbestos[NN]}(DT{no[DT]} no[2])(NN{asbestos[NN]} asbestos[3]))(PP{in[IN]}"
+				+ "(IN{in[IN]} in[4])(NP{products[NNS]}(PRP${our[PRP$]} our[5])(NNS{products[NNS]} products[6])))"
+				+ "(ADVP{now[RB]}(RB{now[RB]} now[7])))(.{.[.]} .[8])(''{''['']} ''[9]))";
+		
 		assertEquals(headTree1.toString(),result1);
 		assertEquals(headTree2.toString(),result2);
 	}

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisContextGeneratorConfTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisContextGeneratorConfTest.java
@@ -19,145 +19,150 @@ import com.lc.nlp4han.constituent.TreeNode;
  */
 public class SyntacticAnalysisContextGeneratorConfTest{
 
-	private BracketExpUtil pgt;
-	private TreeToHeadTree ttht;
+	private AbstractGenerateHeadWords aghw;
 	private TreeNode tree;
     private HeadTreeNode headTree;
-	private HeadTreeToActions tta;
 	private SyntacticAnalysisSample<HeadTreeNode> sample;
-	private List<HeadTreeNode> chunkTree;
-	private List<List<HeadTreeNode>> buildAndCheckTree;
 	private List<String> actions;
-	private String[][] ac;
 	private SyntacticAnalysisContextGenerator<HeadTreeNode> generator;
-	
-	private String[] chunk0 = {"chunkandpostag0=PRP|I","chunkandpostag0*=PRP","chunkandpostag1=VBD|saw","chunkandpostag1*=VBD","chunkandpostag2=DT|the",
-			"chunkandpostag2*=DT","chunkandpostag01=PRP|I;VBD|saw","chunkandpostag01*=PRP|I;VBD","chunkandpostag0*1=PRP;VBD|saw","chunkandpostag0*1*=PRP;VBD"};
-	private String[] chunk1 = {"chunkandpostag0=VBD|saw","chunkandpostag0*=VBD","chunkandpostag_1=start_NP|PRP|I","chunkandpostag_1*=start_NP|PRP","chunkandpostag1=DT|the",
-			"chunkandpostag1*=DT","chunkandpostag2=NN|man","chunkandpostag2*=NN","chunkandpostag_10=start_NP|PRP|I;VBD|saw","chunkandpostag_10*=start_NP|PRP|I;VBD",
-			"chunkandpostag_1*0=start_NP|PRP;VBD|saw","chunkandpostag_1*0*=start_NP|PRP;VBD","chunkandpostag01=VBD|saw;DT|the",
-			"chunkandpostag01*=VBD|saw;DT","chunkandpostag0*1=VBD;DT|the","chunkandpostag0*1*=VBD;DT"};
-	private String[] chunk2 = {"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|VBD|saw","chunkandpostag_1*=other|VBD","chunkandpostag_2=start_NP|PRP|I",
-			"chunkandpostag_2*=start_NP|PRP","chunkandpostag1=NN|man","chunkandpostag1*=NN","chunkandpostag2=IN|with","chunkandpostag2*=IN",
-			"chunkandpostag_10=other|VBD|saw;DT|the","chunkandpostag_10*=other|VBD|saw;DT","chunkandpostag_1*0=other|VBD;DT|the","chunkandpostag_1*0*=other|VBD;DT",
-			"chunkandpostag01=DT|the;NN|man","chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|man","chunkandpostag0*1*=DT;NN"};
-	private String[] chunk5 = {"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|IN|with","chunkandpostag_1*=other|IN","chunkandpostag_2=join_NP|NN|man",
-			"chunkandpostag_2*=join_NP|NN","chunkandpostag1=NN|telescope","chunkandpostag1*=NN","chunkandpostag_10=other|IN|with;DT|the","chunkandpostag_10*=other|IN|with;DT",
-			"chunkandpostag_1*0=other|IN;DT|the","chunkandpostag_1*0*=other|IN;DT","chunkandpostag01=DT|the;NN|telescope",
-			"chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|telescope","chunkandpostag0*1*=DT;NN"};
-	private String[] chunk4 = {"chunkandpostag0=IN|with","chunkandpostag0*=IN","chunkandpostag_1=join_NP|NN|man","chunkandpostag_1*=join_NP|NN","chunkandpostag_2=start_NP|DT|the",
-			"chunkandpostag_2*=start_NP|DT","chunkandpostag1=DT|the","chunkandpostag1*=DT","chunkandpostag2=NN|telescope","chunkandpostag2*=NN",
-			"chunkandpostag_10=join_NP|NN|man;IN|with","chunkandpostag_10*=join_NP|NN|man;IN","chunkandpostag_1*0=join_NP|NN;IN|with","chunkandpostag_1*0*=join_NP|NN;IN",
-			"chunkandpostag01=IN|with;DT|the","chunkandpostag01*=IN|with;DT","chunkandpostag0*1=IN;DT|the","chunkandpostag0*1*=IN;DT"};
-	private String[] chunk3 = {"chunkandpostag0=NN|man","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT",
-			"chunkandpostag_2=other|VBD|saw","chunkandpostag_2*=other|VBD","chunkandpostag1=IN|with","chunkandpostag1*=IN",
-			"chunkandpostag2=DT|the","chunkandpostag2*=DT",
-			"chunkandpostag_10=start_NP|DT|the;NN|man","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|man","chunkandpostag_1*0*=start_NP|DT;NN",
-			"chunkandpostag01=NN|man;IN|with","chunkandpostag01*=NN|man;IN","chunkandpostag0*1=NN;IN|with","chunkandpostag0*1*=NN;IN"};
-	private String[] chunk6 = {"chunkandpostag0=NN|telescope","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT","chunkandpostag_2=other|IN|with",
-			"chunkandpostag_2*=other|IN","chunkandpostag_10=start_NP|DT|the;NN|telescope","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|telescope","chunkandpostag_1*0*=start_NP|DT;NN"};
-	
-	private String[] build0 = {"cons0=NP|I","cons0*=NP","cons1=VBD|saw","cons1*=VBD","cons2=NP|man","cons2*=NP",
-			"cons01=NP|I;VBD|saw","cons01*=NP|I;VBD","cons0*1=NP;VBD|saw","cons0*1*=NP;VBD",
-			"cons012=NP|I;VBD|saw;NP|man","cons01*2*=NP|I;VBD;NP","cons01*2=NP|I;VBD;NP|man","cons012*=NP|I;VBD|saw;NP","cons0*1*2*=NP;VBD;NP"};
-	private String[] build1 = {"cons0=VBD|saw","cons0*=VBD","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=NP|man","cons1*=NP",
-			"cons2=IN|with","cons2*=IN","cons_10=start_S|NP|I;VBD|saw","cons_10*=start_S|NP|I;VBD","cons_1*0=start_S|NP;VBD|saw","cons_1*0*=start_S|NP;VBD",
-			"cons01=VBD|saw;NP|man","cons01*=VBD|saw;NP","cons0*1=VBD;NP|man","cons0*1*=VBD;NP",
-			"cons012=VBD|saw;NP|man;IN|with","cons01*2*=VBD|saw;NP;IN","cons01*2=VBD|saw;NP;IN|with","cons012*=VBD|saw;NP|man;IN","cons0*1*2*=VBD;NP;IN",
-			"cons_101=start_S|NP|I;VBD|saw;NP|man","cons_1*01*=start_S|NP;VBD|saw;NP","cons_1*01=start_S|NP;VBD|saw;NP|man","cons_101*=start_S|NP|I;VBD|saw;NP","cons_1*0*1*=start_S|NP;VBD;NP"};
-	private String[] build2 = {"cons0=NP|man","cons0*=NP","cons_1=start_VP|VBD|saw","cons_1*=start_VP|VBD","cons_2=start_S|NP|I","cons_2*=start_S|NP",
-			"cons1=IN|with","cons1*=IN","cons2=NP|telescope","cons2*=NP",
-			"cons_10=start_VP|VBD|saw;NP|man","cons_10*=start_VP|VBD|saw;NP","cons_1*0=start_VP|VBD;NP|man","cons_1*0*=start_VP|VBD;NP",
-			"cons01=NP|man;IN|with","cons01*=NP|man;IN","cons0*1=NP;IN|with","cons0*1*=NP;IN",
-			"cons_2_10=start_S|NP|I;start_VP|VBD|saw;NP|man","cons_2*_1*0=start_S|NP;start_VP|VBD;NP|man","cons_2*_10=start_S|NP;start_VP|VBD|saw;NP|man","cons_2_1*0=start_S|NP|I;start_VP|VBD;NP|man","cons_2*_1*0*=start_S|NP;start_VP|VBD;NP",
-			"cons012=NP|man;IN|with;NP|telescope","cons01*2*=NP|man;IN;NP","cons01*2=NP|man;IN;NP|telescope","cons012*=NP|man;IN|with;NP","cons0*1*2*=NP;IN;NP",
-			"cons_101=start_VP|VBD|saw;NP|man;IN|with","cons_1*01*=start_VP|VBD;NP|man;IN","cons_1*01=start_VP|VBD;NP|man;IN|with","cons_101*=start_VP|VBD|saw;NP|man;IN","cons_1*0*1*=start_VP|VBD;NP;IN"};
-	private String[] build3 = {"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=IN|with","cons1*=IN",
-			"cons2=NP|telescope","cons2*=NP","cons_10=start_S|NP|I;VP|saw","cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP",
-			"cons01=VP|saw;IN|with","cons01*=VP|saw;IN","cons0*1=VP;IN|with","cons0*1*=VP;IN",
-			"cons012=VP|saw;IN|with;NP|telescope","cons01*2*=VP|saw;IN;NP","cons01*2=VP|saw;IN;NP|telescope","cons012*=VP|saw;IN|with;NP","cons0*1*2*=VP;IN;NP",
-			"cons_101=start_S|NP|I;VP|saw;IN|with","cons_1*01*=start_S|NP;VP|saw;IN","cons_1*01=start_S|NP;VP|saw;IN|with","cons_101*=start_S|NP|I;VP|saw;IN","cons_1*0*1*=start_S|NP;VP;IN"};
-	private String[] build4 = {"cons0=IN|with","cons0*=IN","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
-			"cons1=NP|telescope","cons1*=NP","cons_10=start_VP|VP|saw;IN|with","cons_10*=start_VP|VP|saw;IN","cons_1*0=start_VP|VP;IN|with","cons_1*0*=start_VP|VP;IN",
-			"cons01=IN|with;NP|telescope","cons01*=IN|with;NP","cons0*1=IN;NP|telescope","cons0*1*=IN;NP",
-			"cons_2_10=start_S|NP|I;start_VP|VP|saw;IN|with","cons_2*_1*0=start_S|NP;start_VP|VP;IN|with","cons_2*_10=start_S|NP;start_VP|VP|saw;IN|with","cons_2_1*0=start_S|NP|I;start_VP|VP;IN|with","cons_2*_1*0*=start_S|NP;start_VP|VP;IN",
-			"cons_101=start_VP|VP|saw;IN|with;NP|telescope","cons_1*01*=start_VP|VP;IN|with;NP","cons_1*01=start_VP|VP;IN|with;NP|telescope","cons_101*=start_VP|VP|saw;IN|with;NP","cons_1*0*1*=start_VP|VP;IN;NP"};
-	private String[] build5 = {"cons0=NP|telescope","cons0*=NP","cons_1=start_PP|IN|with","cons_1*=start_PP|IN","cons_2=start_VP|VP|saw","cons_2*=start_VP|VP",
-			"cons_10=start_PP|IN|with;NP|telescope","cons_10*=start_PP|IN|with;NP","cons_1*0=start_PP|IN;NP|telescope","cons_1*0*=start_PP|IN;NP","cons_2_10=start_VP|VP|saw;start_PP|IN|with;NP|telescope",
-			"cons_2*_1*0=start_VP|VP;start_PP|IN;NP|telescope","cons_2*_10=start_VP|VP;start_PP|IN|with;NP|telescope","cons_2_1*0=start_VP|VP|saw;start_PP|IN;NP|telescope","cons_2*_1*0*=start_VP|VP;start_PP|IN;NP"};
-	private String[] build6 = {"cons0=PP|with","cons0*=PP","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
-			"cons_10=start_VP|VP|saw;PP|with","cons_10*=start_VP|VP|saw;PP","cons_1*0=start_VP|VP;PP|with","cons_1*0*=start_VP|VP;PP",
-			"cons_2_10=start_S|NP|I;start_VP|VP|saw;PP|with","cons_2*_1*0=start_S|NP;start_VP|VP;PP|with","cons_2*_10=start_S|NP;start_VP|VP|saw;PP|with","cons_2_1*0=start_S|NP|I;start_VP|VP;PP|with","cons_2*_1*0*=start_S|NP;start_VP|VP;PP"};
-	private String[] build7 = {"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons_10=start_S|NP|I;VP|saw",
-			"cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP"};
-	
-	private String[] check0 = {"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|NP|I","checkcons_last*=S|NP",
-			"production=S→NP","surround1=VBD|saw","surround1*=VBD","surround2=DT|the;NN|man","surround2*=DT;NN"};
-	private String[] check1 = {"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|VBD|saw","checkcons_last*=VP|VBD","production=VP→VBD",
-			"surround_1=PRP|I","surround_1*=PRP","surround1=DT|the;NN|man","surround1*=DT;NN","surround2=IN|with","surround2*=IN"};
-	private String[] check2 = {"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|NP|man","checkcons_last*=VP|NP","checkcons_0last=VP|VBD|saw;VP|NP|man",
-			"production=VP→VBD,NP","surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN",
-			"surround2=DT|the;NN|telescope","surround2*=DT;NN"};
-	private String[] check3 = {"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|VP|saw","checkcons_last*=VP|VP","production=VP→VP",
-			"surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN","surround2=DT|the;NN|telescope","surround2*=DT;NN"};
-	private String[] check4 = {"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|IN|with","checkcons_last*=PP|IN","production=PP→IN",
-			"surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN","surround_2=PRP|I","surround_2*=PRP","surround1=DT|the;NN|telescope","surround1*=DT;NN"};
-	private String[] check5 = {"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|NP|telescope","checkcons_last*=PP|NP",
-			"checkcons_0last=PP|IN|with;PP|NP|telescope","production=PP→IN,NP","surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN",
-			"surround_2=PRP|I","surround_2*=PRP"};
-	private String[] check6 = {"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|PP|with","checkcons_last*=VP|PP",
-			"checkcons_0last=VP|VP|saw;VP|PP|with","production=VP→VP,PP","surround_1=PRP|I","surround_1*=PRP"};
-	private String[] check7 = {"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|VP|saw","checkcons_last*=S|VP","checkcons_0last=S|NP|I;S|VP|saw",
-			"production=S→NP,VP"};
 
 	@Before
 	public void setUP() throws CloneNotSupportedException, IOException{
-		pgt = new BracketExpUtil();
-		ttht = new TreeToHeadTree();
-		tree = pgt.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
-        headTree = ttht.treeToHeadTree(tree);
-		tta = new HeadTreeToActions();
-		sample = tta.treeToAction(headTree);
-		chunkTree = sample.getChunkTree();
-		buildAndCheckTree = sample.getBuildAndCheckTree();
+   
+		aghw = new ConcreteGenerateHeadWords();
+		tree = BracketExpUtil.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
+        headTree = TreeToHeadTree.treeToHeadTree(tree,aghw);
+		sample = HeadTreeToActions.headTreeToAction(headTree,aghw);
 		actions = sample.getActions();
-		ac = sample.getAdditionalContext();
 		generator = new SyntacticAnalysisContextGeneratorConf();
+	}
+
+	/**
+	 * 对chunk步生成的特征进行测试
+	 */
+	@Test
+	public void testChunkFeature(){
+		List<HeadTreeNode> chunkTree = sample.getChunkTree();
+		
+		String[] chunk0 = new String[]{"chunkandpostag0=PRP|I","chunkandpostag0*=PRP","chunkandpostag1=VBD|saw","chunkandpostag1*=VBD","chunkandpostag2=DT|the",
+				"chunkandpostag2*=DT","chunkandpostag01=PRP|I;VBD|saw","chunkandpostag01*=PRP|I;VBD","chunkandpostag0*1=PRP;VBD|saw","chunkandpostag0*1*=PRP;VBD"};
+		String[] chunk1 = new String[]{"chunkandpostag0=VBD|saw","chunkandpostag0*=VBD","chunkandpostag_1=start_NP|PRP|I","chunkandpostag_1*=start_NP|PRP","chunkandpostag1=DT|the",
+				"chunkandpostag1*=DT","chunkandpostag2=NN|man","chunkandpostag2*=NN","chunkandpostag_10=start_NP|PRP|I;VBD|saw","chunkandpostag_10*=start_NP|PRP|I;VBD",
+				"chunkandpostag_1*0=start_NP|PRP;VBD|saw","chunkandpostag_1*0*=start_NP|PRP;VBD","chunkandpostag01=VBD|saw;DT|the",
+				"chunkandpostag01*=VBD|saw;DT","chunkandpostag0*1=VBD;DT|the","chunkandpostag0*1*=VBD;DT"};
+		String[] chunk2 = new String[]{"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|VBD|saw","chunkandpostag_1*=other|VBD","chunkandpostag_2=start_NP|PRP|I",
+				"chunkandpostag_2*=start_NP|PRP","chunkandpostag1=NN|man","chunkandpostag1*=NN","chunkandpostag2=IN|with","chunkandpostag2*=IN",
+				"chunkandpostag_10=other|VBD|saw;DT|the","chunkandpostag_10*=other|VBD|saw;DT","chunkandpostag_1*0=other|VBD;DT|the","chunkandpostag_1*0*=other|VBD;DT",
+				"chunkandpostag01=DT|the;NN|man","chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|man","chunkandpostag0*1*=DT;NN"};
+		String[] chunk5 = new String[]{"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|IN|with","chunkandpostag_1*=other|IN","chunkandpostag_2=join_NP|NN|man",
+				"chunkandpostag_2*=join_NP|NN","chunkandpostag1=NN|telescope","chunkandpostag1*=NN","chunkandpostag_10=other|IN|with;DT|the","chunkandpostag_10*=other|IN|with;DT",
+				"chunkandpostag_1*0=other|IN;DT|the","chunkandpostag_1*0*=other|IN;DT","chunkandpostag01=DT|the;NN|telescope",
+				"chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|telescope","chunkandpostag0*1*=DT;NN"};
+		String[] chunk4 = new String[]{"chunkandpostag0=IN|with","chunkandpostag0*=IN","chunkandpostag_1=join_NP|NN|man","chunkandpostag_1*=join_NP|NN","chunkandpostag_2=start_NP|DT|the",
+				"chunkandpostag_2*=start_NP|DT","chunkandpostag1=DT|the","chunkandpostag1*=DT","chunkandpostag2=NN|telescope","chunkandpostag2*=NN",
+				"chunkandpostag_10=join_NP|NN|man;IN|with","chunkandpostag_10*=join_NP|NN|man;IN","chunkandpostag_1*0=join_NP|NN;IN|with","chunkandpostag_1*0*=join_NP|NN;IN",
+				"chunkandpostag01=IN|with;DT|the","chunkandpostag01*=IN|with;DT","chunkandpostag0*1=IN;DT|the","chunkandpostag0*1*=IN;DT"};
+		String[] chunk3 = new String[]{"chunkandpostag0=NN|man","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT",
+				"chunkandpostag_2=other|VBD|saw","chunkandpostag_2*=other|VBD","chunkandpostag1=IN|with","chunkandpostag1*=IN",
+				"chunkandpostag2=DT|the","chunkandpostag2*=DT",
+				"chunkandpostag_10=start_NP|DT|the;NN|man","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|man","chunkandpostag_1*0*=start_NP|DT;NN",
+				"chunkandpostag01=NN|man;IN|with","chunkandpostag01*=NN|man;IN","chunkandpostag0*1=NN;IN|with","chunkandpostag0*1*=NN;IN"};
+		String[] chunk6 = new String[]{"chunkandpostag0=NN|telescope","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT","chunkandpostag_2=other|IN|with",
+				"chunkandpostag_2*=other|IN","chunkandpostag_10=start_NP|DT|the;NN|telescope","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|telescope","chunkandpostag_1*0*=start_NP|DT;NN"};
+		
+		assertArrayEquals(generator.getContextForChunk(0,chunkTree, actions, null),chunk0);
+		assertArrayEquals(generator.getContextForChunk(1,chunkTree, actions, null),chunk1);
+		assertArrayEquals(generator.getContextForChunk(2,chunkTree, actions, null),chunk2);
+		assertArrayEquals(generator.getContextForChunk(3,chunkTree, actions, null),chunk3);
+		assertArrayEquals(generator.getContextForChunk(4,chunkTree, actions, null),chunk4);
+		assertArrayEquals(generator.getContextForChunk(5,chunkTree, actions, null),chunk5);
+		assertArrayEquals(generator.getContextForChunk(6,chunkTree, actions, null),chunk6);
 	}
 	
 	/**
-	 * 对生成的特征进行测试
-	 * @throws IOException
-	 * @throws CloneNotSupportedException
+	 * 对build步生成的特征进行测试
 	 */
 	@Test
-	public void testFeature() throws IOException, CloneNotSupportedException{
+	public void testBuildFeature(){
+		List<List<HeadTreeNode>> buildAndCheckTree = sample.getBuildAndCheckTree();
 		
-		//chunk的特征
-		assertArrayEquals(generator.getContextForChunk(0,chunkTree, actions, ac),chunk0);
-		assertArrayEquals(generator.getContextForChunk(1,chunkTree, actions, ac),chunk1);
-		assertArrayEquals(generator.getContextForChunk(2,chunkTree, actions, ac),chunk2);
-		assertArrayEquals(generator.getContextForChunk(3,chunkTree, actions, ac),chunk3);
-		assertArrayEquals(generator.getContextForChunk(4,chunkTree, actions, ac),chunk4);
-		assertArrayEquals(generator.getContextForChunk(5,chunkTree, actions, ac),chunk5);
-		assertArrayEquals(generator.getContextForChunk(6,chunkTree, actions, ac),chunk6);
-		//build步骤
-	    assertArrayEquals(generator.getContextForBuild(0,buildAndCheckTree.get(0), actions, ac),build0);
-		assertArrayEquals(generator.getContextForBuild(1,buildAndCheckTree.get(2), actions, ac),build1);
-		assertArrayEquals(generator.getContextForBuild(2,buildAndCheckTree.get(4), actions, ac),build2);
-		assertArrayEquals(generator.getContextForBuild(1,buildAndCheckTree.get(6), actions, ac),build3);
-		assertArrayEquals(generator.getContextForBuild(2,buildAndCheckTree.get(8), actions, ac),build4);
-		assertArrayEquals(generator.getContextForBuild(3,buildAndCheckTree.get(10), actions, ac),build5);
-		assertArrayEquals(generator.getContextForBuild(2,buildAndCheckTree.get(12), actions, ac),build6);
-		assertArrayEquals(generator.getContextForBuild(1,buildAndCheckTree.get(14), actions, ac),build7);				
-		//check步骤
-		assertArrayEquals(generator.getContextForCheck(0,buildAndCheckTree.get(1), actions, ac),check0);
-		assertArrayEquals(generator.getContextForCheck(1,buildAndCheckTree.get(3), actions, ac),check1);
-		assertArrayEquals(generator.getContextForCheck(2,buildAndCheckTree.get(5), actions, ac),check2);
-		assertArrayEquals(generator.getContextForCheck(1,buildAndCheckTree.get(7), actions, ac),check3);
-		assertArrayEquals(generator.getContextForCheck(2,buildAndCheckTree.get(9), actions, ac),check4);
-		assertArrayEquals(generator.getContextForCheck(3,buildAndCheckTree.get(11), actions, ac),check5);
-		assertArrayEquals(generator.getContextForCheck(2,buildAndCheckTree.get(13), actions, ac),check6);
-		assertArrayEquals(generator.getContextForCheck(1,buildAndCheckTree.get(15), actions, ac),check7);
+		String[] build0 = new String[]{"cons0=NP|I","cons0*=NP","cons1=VBD|saw","cons1*=VBD","cons2=NP|man","cons2*=NP",
+				"cons01=NP|I;VBD|saw","cons01*=NP|I;VBD","cons0*1=NP;VBD|saw","cons0*1*=NP;VBD",
+				"cons012=NP|I;VBD|saw;NP|man","cons01*2*=NP|I;VBD;NP","cons01*2=NP|I;VBD;NP|man","cons012*=NP|I;VBD|saw;NP","cons0*1*2*=NP;VBD;NP"};
+		String[] build1 = new String[]{"cons0=VBD|saw","cons0*=VBD","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=NP|man","cons1*=NP",
+				"cons2=IN|with","cons2*=IN","cons_10=start_S|NP|I;VBD|saw","cons_10*=start_S|NP|I;VBD","cons_1*0=start_S|NP;VBD|saw","cons_1*0*=start_S|NP;VBD",
+				"cons01=VBD|saw;NP|man","cons01*=VBD|saw;NP","cons0*1=VBD;NP|man","cons0*1*=VBD;NP",
+				"cons012=VBD|saw;NP|man;IN|with","cons01*2*=VBD|saw;NP;IN","cons01*2=VBD|saw;NP;IN|with","cons012*=VBD|saw;NP|man;IN","cons0*1*2*=VBD;NP;IN",
+				"cons_101=start_S|NP|I;VBD|saw;NP|man","cons_1*01*=start_S|NP;VBD|saw;NP","cons_1*01=start_S|NP;VBD|saw;NP|man","cons_101*=start_S|NP|I;VBD|saw;NP","cons_1*0*1*=start_S|NP;VBD;NP"};
+		String[] build2 = new String[]{"cons0=NP|man","cons0*=NP","cons_1=start_VP|VBD|saw","cons_1*=start_VP|VBD","cons_2=start_S|NP|I","cons_2*=start_S|NP",
+				"cons1=IN|with","cons1*=IN","cons2=NP|telescope","cons2*=NP",
+				"cons_10=start_VP|VBD|saw;NP|man","cons_10*=start_VP|VBD|saw;NP","cons_1*0=start_VP|VBD;NP|man","cons_1*0*=start_VP|VBD;NP",
+				"cons01=NP|man;IN|with","cons01*=NP|man;IN","cons0*1=NP;IN|with","cons0*1*=NP;IN",
+				"cons_2_10=start_S|NP|I;start_VP|VBD|saw;NP|man","cons_2*_1*0=start_S|NP;start_VP|VBD;NP|man","cons_2*_10=start_S|NP;start_VP|VBD|saw;NP|man","cons_2_1*0=start_S|NP|I;start_VP|VBD;NP|man","cons_2*_1*0*=start_S|NP;start_VP|VBD;NP",
+				"cons012=NP|man;IN|with;NP|telescope","cons01*2*=NP|man;IN;NP","cons01*2=NP|man;IN;NP|telescope","cons012*=NP|man;IN|with;NP","cons0*1*2*=NP;IN;NP",
+				"cons_101=start_VP|VBD|saw;NP|man;IN|with","cons_1*01*=start_VP|VBD;NP|man;IN","cons_1*01=start_VP|VBD;NP|man;IN|with","cons_101*=start_VP|VBD|saw;NP|man;IN","cons_1*0*1*=start_VP|VBD;NP;IN"};
+		String[] build3 = new String[]{"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=IN|with","cons1*=IN",
+				"cons2=NP|telescope","cons2*=NP","cons_10=start_S|NP|I;VP|saw","cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP",
+				"cons01=VP|saw;IN|with","cons01*=VP|saw;IN","cons0*1=VP;IN|with","cons0*1*=VP;IN",
+				"cons012=VP|saw;IN|with;NP|telescope","cons01*2*=VP|saw;IN;NP","cons01*2=VP|saw;IN;NP|telescope","cons012*=VP|saw;IN|with;NP","cons0*1*2*=VP;IN;NP",
+				"cons_101=start_S|NP|I;VP|saw;IN|with","cons_1*01*=start_S|NP;VP|saw;IN","cons_1*01=start_S|NP;VP|saw;IN|with","cons_101*=start_S|NP|I;VP|saw;IN","cons_1*0*1*=start_S|NP;VP;IN"};
+		String[] build4 = new String[]{"cons0=IN|with","cons0*=IN","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
+				"cons1=NP|telescope","cons1*=NP","cons_10=start_VP|VP|saw;IN|with","cons_10*=start_VP|VP|saw;IN","cons_1*0=start_VP|VP;IN|with","cons_1*0*=start_VP|VP;IN",
+				"cons01=IN|with;NP|telescope","cons01*=IN|with;NP","cons0*1=IN;NP|telescope","cons0*1*=IN;NP",
+				"cons_2_10=start_S|NP|I;start_VP|VP|saw;IN|with","cons_2*_1*0=start_S|NP;start_VP|VP;IN|with","cons_2*_10=start_S|NP;start_VP|VP|saw;IN|with","cons_2_1*0=start_S|NP|I;start_VP|VP;IN|with","cons_2*_1*0*=start_S|NP;start_VP|VP;IN",
+				"cons_101=start_VP|VP|saw;IN|with;NP|telescope","cons_1*01*=start_VP|VP;IN|with;NP","cons_1*01=start_VP|VP;IN|with;NP|telescope","cons_101*=start_VP|VP|saw;IN|with;NP","cons_1*0*1*=start_VP|VP;IN;NP"};
+		String[] build5 = new String[]{"cons0=NP|telescope","cons0*=NP","cons_1=start_PP|IN|with","cons_1*=start_PP|IN","cons_2=start_VP|VP|saw","cons_2*=start_VP|VP",
+				"cons_10=start_PP|IN|with;NP|telescope","cons_10*=start_PP|IN|with;NP","cons_1*0=start_PP|IN;NP|telescope","cons_1*0*=start_PP|IN;NP","cons_2_10=start_VP|VP|saw;start_PP|IN|with;NP|telescope",
+				"cons_2*_1*0=start_VP|VP;start_PP|IN;NP|telescope","cons_2*_10=start_VP|VP;start_PP|IN|with;NP|telescope","cons_2_1*0=start_VP|VP|saw;start_PP|IN;NP|telescope","cons_2*_1*0*=start_VP|VP;start_PP|IN;NP"};
+		String[] build6 = new String[]{"cons0=PP|with","cons0*=PP","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
+				"cons_10=start_VP|VP|saw;PP|with","cons_10*=start_VP|VP|saw;PP","cons_1*0=start_VP|VP;PP|with","cons_1*0*=start_VP|VP;PP",
+				"cons_2_10=start_S|NP|I;start_VP|VP|saw;PP|with","cons_2*_1*0=start_S|NP;start_VP|VP;PP|with","cons_2*_10=start_S|NP;start_VP|VP|saw;PP|with","cons_2_1*0=start_S|NP|I;start_VP|VP;PP|with","cons_2*_1*0*=start_S|NP;start_VP|VP;PP"};
+		String[] build7 = new String[]{"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons_10=start_S|NP|I;VP|saw",
+				"cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP"};
+		
+	    assertArrayEquals(generator.getContextForBuild(0,buildAndCheckTree.get(0), actions, null),build0);
+		assertArrayEquals(generator.getContextForBuild(1,buildAndCheckTree.get(2), actions, null),build1);
+		assertArrayEquals(generator.getContextForBuild(2,buildAndCheckTree.get(4), actions, null),build2);
+		assertArrayEquals(generator.getContextForBuild(1,buildAndCheckTree.get(6), actions, null),build3);
+		assertArrayEquals(generator.getContextForBuild(2,buildAndCheckTree.get(8), actions, null),build4);
+		assertArrayEquals(generator.getContextForBuild(3,buildAndCheckTree.get(10), actions, null),build5);
+		assertArrayEquals(generator.getContextForBuild(2,buildAndCheckTree.get(12), actions, null),build6);
+		assertArrayEquals(generator.getContextForBuild(1,buildAndCheckTree.get(14), actions, null),build7);			
+	}
+	
+	/**
+	 * 对check步生成的特征进行测试
+	 */
+	@Test
+	public void testCheckFeature(){
+		List<List<HeadTreeNode>> buildAndCheckTree = sample.getBuildAndCheckTree();
+		
+		String[] check0 = new String[]{"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|NP|I","checkcons_last*=S|NP",
+				"production=S→NP","surround1=VBD|saw","surround1*=VBD","surround2=DT|the;NN|man","surround2*=DT;NN"};
+		String[] check1 = new String[]{"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|VBD|saw","checkcons_last*=VP|VBD","production=VP→VBD",
+				"surround_1=PRP|I","surround_1*=PRP","surround1=DT|the;NN|man","surround1*=DT;NN","surround2=IN|with","surround2*=IN"};
+		String[] check2 = new String[]{"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|NP|man","checkcons_last*=VP|NP","checkcons_0last=VP|VBD|saw;VP|NP|man",
+				"production=VP→VBD,NP","surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN",
+				"surround2=DT|the;NN|telescope","surround2*=DT;NN"};
+		String[] check3 = new String[]{"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|VP|saw","checkcons_last*=VP|VP","production=VP→VP",
+				"surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN","surround2=DT|the;NN|telescope","surround2*=DT;NN"};
+		String[] check4 = new String[]{"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|IN|with","checkcons_last*=PP|IN","production=PP→IN",
+				"surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN","surround_2=PRP|I","surround_2*=PRP","surround1=DT|the;NN|telescope","surround1*=DT;NN"};
+		String[] check5 = new String[]{"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|NP|telescope","checkcons_last*=PP|NP",
+				"checkcons_0last=PP|IN|with;PP|NP|telescope","production=PP→IN,NP","surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN",
+				"surround_2=PRP|I","surround_2*=PRP"};
+		String[] check6 = new String[]{"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|PP|with","checkcons_last*=VP|PP",
+				"checkcons_0last=VP|VP|saw;VP|PP|with","production=VP→VP,PP","surround_1=PRP|I","surround_1*=PRP"};
+		String[] check7 = new String[]{"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|VP|saw","checkcons_last*=S|VP","checkcons_0last=S|NP|I;S|VP|saw",
+				"production=S→NP,VP"};
+		
+		assertArrayEquals(generator.getContextForCheck(0,buildAndCheckTree.get(1), actions, null),check0);
+		assertArrayEquals(generator.getContextForCheck(1,buildAndCheckTree.get(3), actions, null),check1);
+		assertArrayEquals(generator.getContextForCheck(2,buildAndCheckTree.get(5), actions, null),check2);
+		assertArrayEquals(generator.getContextForCheck(1,buildAndCheckTree.get(7), actions, null),check3);
+		assertArrayEquals(generator.getContextForCheck(2,buildAndCheckTree.get(9), actions, null),check4);
+		assertArrayEquals(generator.getContextForCheck(3,buildAndCheckTree.get(11), actions, null),check5);
+		assertArrayEquals(generator.getContextForCheck(2,buildAndCheckTree.get(13), actions, null),check6);
+		assertArrayEquals(generator.getContextForCheck(1,buildAndCheckTree.get(15), actions, null),check7);		
 	}
 }

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisMeasureTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisMeasureTest.java
@@ -2,7 +2,6 @@ package com.lc.nlp4han.constituent.maxent;
 
 import static org.junit.Assert.*;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.lc.nlp4han.constituent.BracketExpUtil;
@@ -16,32 +15,13 @@ import com.lc.nlp4han.constituent.TreeNode;
  */
 public class SyntacticAnalysisMeasureTest {
 
-	private BracketExpUtil pgt;
-	private TreeNode treeRef1;
-	private TreeNode treePre1;
-	private SyntacticAnalysisMeasure measure1;
-	private TreeNode treeRef2;
-	private TreeNode treePre2;
-	private SyntacticAnalysisMeasure measure2;
-	
-	@Before
-	public void setUp() throws CloneNotSupportedException{
-		pgt = new BracketExpUtil();
-		measure1 = new SyntacticAnalysisMeasure();
-		//两棵树不同
-		treeRef1 = pgt.generateTree("((S(NP(NN Measuring)(NNS cups))(VP(MD may)(ADVP(RB soon))(VP(VB be)(VP(VBN replaced)(PP(IN by)(NP(NNS tablespoons)))(PP(IN in)(NP(DT the)(NN laundry)(NN room))))))(. .)))");
-		treePre1 = pgt.generateTree("((S(NP(VBG Measuring)(NNS cups))(VP(MD may)(ADVP(RB soon))(VP(VB be)(VP(VBN replaced)(PP(IN by)(NP(NP(NNS tablespoons))(PP(IN in)(NP(DT the)(NN laundry)(NN room))))))))(. .)))");
-		measure1.update(treeRef1, treePre1);
-		
-		measure2 = new SyntacticAnalysisMeasure();	
-		//两颗树相同的
-		treeRef2 = pgt.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
-		treePre2 = pgt.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
-		measure2.update(treeRef2, treePre2);
-	}
-	
 	@Test
-	public void test(){
+	public void test() throws CloneNotSupportedException{
+		//两棵树不同
+		TreeNode treeRef1 = BracketExpUtil.generateTree("((S(NP(NN Measuring)(NNS cups))(VP(MD may)(ADVP(RB soon))(VP(VB be)(VP(VBN replaced)(PP(IN by)(NP(NNS tablespoons)))(PP(IN in)(NP(DT the)(NN laundry)(NN room))))))(. .)))");
+		TreeNode treePre1 = BracketExpUtil.generateTree("((S(NP(VBG Measuring)(NNS cups))(VP(MD may)(ADVP(RB soon))(VP(VB be)(VP(VBN replaced)(PP(IN by)(NP(NP(NNS tablespoons))(PP(IN in)(NP(DT the)(NN laundry)(NN room))))))))(. .)))");
+		SyntacticAnalysisMeasure measure1 = new SyntacticAnalysisMeasure();
+		measure1.update(treeRef1, treePre1);
 		assertEquals(measure1.getPrecisionScore(),0.8181,0.001);
 		assertEquals(measure1.getRecallScore(),0.9,0.001);
 		assertEquals(measure1.getMeasure(),0.8570,0.001);
@@ -50,6 +30,11 @@ public class SyntacticAnalysisMeasureTest {
 		assertEquals(measure1.getCBs_2(),1,0.001);
 		assertEquals(measure1.getSentenceAccuracy(),0,0.001);
 		
+		//两颗树相同的
+		TreeNode treeRef2 = BracketExpUtil.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
+		TreeNode treePre2 = BracketExpUtil.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
+		SyntacticAnalysisMeasure measure2 = new SyntacticAnalysisMeasure();
+		measure2.update(treeRef2, treePre2);
 		assertEquals(measure2.getPrecisionScore(),1.0,0.001);
 		assertEquals(measure2.getRecallScore(),1.0,0.001);
 		assertEquals(measure2.getMeasure(),1.0,0.001);

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/SyntacticAnalysisSampleEventTest.java
@@ -22,145 +22,40 @@ import com.lc.nlp4han.ml.model.Event;
  */
 public class SyntacticAnalysisSampleEventTest {
 
-	private BracketExpUtil pgt;
-	private TreeToHeadTree ttht;
-	private TreeNode tree;
-    private HeadTreeNode headTree;
-	private HeadTreeToActions tta;
-	private SyntacticAnalysisSample<HeadTreeNode> sample;
-	private List<String> words;
-	private List<HeadTreeNode> chunkTree;
-	private List<List<HeadTreeNode>> buildAndCheckTree;
-	private List<String> actions;
-	private String[][] ac;
-	private SyntacticAnalysisContextGenerator<HeadTreeNode> generator;
-	private List<Event> events = new ArrayList<Event>();	
-	private List<Event> event1 = new ArrayList<>();
-	private List<Event> event2 = new ArrayList<>();
-	private List<Event> event3 = new ArrayList<>();
-	private List<Event> event4 = new ArrayList<>();
-	private List<Event> event5 = new ArrayList<>();
-	private List<Event> event6 = new ArrayList<>();
-	private List<Event> event7 = new ArrayList<>();
-	private List<Event> event8 = new ArrayList<>();
-	private List<Event> event9 = new ArrayList<>();
-	private List<Event> event10 = new ArrayList<>();
-	private List<Event> event11 = new ArrayList<>();
-	private List<Event> event12 = new ArrayList<>();
-	private List<Event> event13 = new ArrayList<>();
-	private List<Event> event14 = new ArrayList<>();
-	private List<Event> event15 = new ArrayList<>();
-	private List<Event> event16 = new ArrayList<>();
-	private List<Event> event17 = new ArrayList<>();
-	private List<Event> event18 = new ArrayList<>();
-	private List<Event> event19 = new ArrayList<>();
-	private List<Event> event20 = new ArrayList<>();
-	private List<Event> event21 = new ArrayList<>();
-	private List<Event> event22 = new ArrayList<>();
-	private List<Event> event23 = new ArrayList<>();
-	
-	private String[] chunk0 = {"chunkandpostag0=PRP|I","chunkandpostag0*=PRP","chunkandpostag1=VBD|saw","chunkandpostag1*=VBD","chunkandpostag2=DT|the",
-			"chunkandpostag2*=DT","chunkandpostag01=PRP|I;VBD|saw","chunkandpostag01*=PRP|I;VBD","chunkandpostag0*1=PRP;VBD|saw","chunkandpostag0*1*=PRP;VBD"};
-	private String[] chunk1 = {"chunkandpostag0=VBD|saw","chunkandpostag0*=VBD","chunkandpostag_1=start_NP|PRP|I","chunkandpostag_1*=start_NP|PRP","chunkandpostag1=DT|the",
-			"chunkandpostag1*=DT","chunkandpostag2=NN|man","chunkandpostag2*=NN","chunkandpostag_10=start_NP|PRP|I;VBD|saw","chunkandpostag_10*=start_NP|PRP|I;VBD",
-			"chunkandpostag_1*0=start_NP|PRP;VBD|saw","chunkandpostag_1*0*=start_NP|PRP;VBD","chunkandpostag01=VBD|saw;DT|the",
-			"chunkandpostag01*=VBD|saw;DT","chunkandpostag0*1=VBD;DT|the","chunkandpostag0*1*=VBD;DT"};
-	private String[] chunk2 = {"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|VBD|saw","chunkandpostag_1*=other|VBD","chunkandpostag_2=start_NP|PRP|I",
-			"chunkandpostag_2*=start_NP|PRP","chunkandpostag1=NN|man","chunkandpostag1*=NN","chunkandpostag2=IN|with","chunkandpostag2*=IN",
-			"chunkandpostag_10=other|VBD|saw;DT|the","chunkandpostag_10*=other|VBD|saw;DT","chunkandpostag_1*0=other|VBD;DT|the","chunkandpostag_1*0*=other|VBD;DT",
-			"chunkandpostag01=DT|the;NN|man","chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|man","chunkandpostag0*1*=DT;NN"};
-	private String[] chunk5 = {"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|IN|with","chunkandpostag_1*=other|IN","chunkandpostag_2=join_NP|NN|man",
-			"chunkandpostag_2*=join_NP|NN","chunkandpostag1=NN|telescope","chunkandpostag1*=NN","chunkandpostag_10=other|IN|with;DT|the","chunkandpostag_10*=other|IN|with;DT",
-			"chunkandpostag_1*0=other|IN;DT|the","chunkandpostag_1*0*=other|IN;DT","chunkandpostag01=DT|the;NN|telescope",
-			"chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|telescope","chunkandpostag0*1*=DT;NN"};
-	private String[] chunk4 = {"chunkandpostag0=IN|with","chunkandpostag0*=IN","chunkandpostag_1=join_NP|NN|man","chunkandpostag_1*=join_NP|NN","chunkandpostag_2=start_NP|DT|the",
-			"chunkandpostag_2*=start_NP|DT","chunkandpostag1=DT|the","chunkandpostag1*=DT","chunkandpostag2=NN|telescope","chunkandpostag2*=NN",
-			"chunkandpostag_10=join_NP|NN|man;IN|with","chunkandpostag_10*=join_NP|NN|man;IN","chunkandpostag_1*0=join_NP|NN;IN|with","chunkandpostag_1*0*=join_NP|NN;IN",
-			"chunkandpostag01=IN|with;DT|the","chunkandpostag01*=IN|with;DT","chunkandpostag0*1=IN;DT|the","chunkandpostag0*1*=IN;DT"};
-	private String[] chunk3 = {"chunkandpostag0=NN|man","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT",
-			"chunkandpostag_2=other|VBD|saw","chunkandpostag_2*=other|VBD","chunkandpostag1=IN|with","chunkandpostag1*=IN",
-			"chunkandpostag2=DT|the","chunkandpostag2*=DT",
-			"chunkandpostag_10=start_NP|DT|the;NN|man","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|man","chunkandpostag_1*0*=start_NP|DT;NN",
-			"chunkandpostag01=NN|man;IN|with","chunkandpostag01*=NN|man;IN","chunkandpostag0*1=NN;IN|with","chunkandpostag0*1*=NN;IN"};
-	private String[] chunk6 = {"chunkandpostag0=NN|telescope","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT","chunkandpostag_2=other|IN|with",
-			"chunkandpostag_2*=other|IN","chunkandpostag_10=start_NP|DT|the;NN|telescope","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|telescope","chunkandpostag_1*0*=start_NP|DT;NN"};
-	
-	private String[] build0 = {"cons0=NP|I","cons0*=NP","cons1=VBD|saw","cons1*=VBD","cons2=NP|man","cons2*=NP",
-			"cons01=NP|I;VBD|saw","cons01*=NP|I;VBD","cons0*1=NP;VBD|saw","cons0*1*=NP;VBD",
-			"cons012=NP|I;VBD|saw;NP|man","cons01*2*=NP|I;VBD;NP","cons01*2=NP|I;VBD;NP|man","cons012*=NP|I;VBD|saw;NP","cons0*1*2*=NP;VBD;NP"};
-	private String[] build1 = {"cons0=VBD|saw","cons0*=VBD","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=NP|man","cons1*=NP",
-			"cons2=IN|with","cons2*=IN","cons_10=start_S|NP|I;VBD|saw","cons_10*=start_S|NP|I;VBD","cons_1*0=start_S|NP;VBD|saw","cons_1*0*=start_S|NP;VBD",
-			"cons01=VBD|saw;NP|man","cons01*=VBD|saw;NP","cons0*1=VBD;NP|man","cons0*1*=VBD;NP",
-			"cons012=VBD|saw;NP|man;IN|with","cons01*2*=VBD|saw;NP;IN","cons01*2=VBD|saw;NP;IN|with","cons012*=VBD|saw;NP|man;IN","cons0*1*2*=VBD;NP;IN",
-			"cons_101=start_S|NP|I;VBD|saw;NP|man","cons_1*01*=start_S|NP;VBD|saw;NP","cons_1*01=start_S|NP;VBD|saw;NP|man","cons_101*=start_S|NP|I;VBD|saw;NP","cons_1*0*1*=start_S|NP;VBD;NP"};
-	private String[] build2 = {"cons0=NP|man","cons0*=NP","cons_1=start_VP|VBD|saw","cons_1*=start_VP|VBD","cons_2=start_S|NP|I","cons_2*=start_S|NP",
-			"cons1=IN|with","cons1*=IN","cons2=NP|telescope","cons2*=NP",
-			"cons_10=start_VP|VBD|saw;NP|man","cons_10*=start_VP|VBD|saw;NP","cons_1*0=start_VP|VBD;NP|man","cons_1*0*=start_VP|VBD;NP",
-			"cons01=NP|man;IN|with","cons01*=NP|man;IN","cons0*1=NP;IN|with","cons0*1*=NP;IN",
-			"cons_2_10=start_S|NP|I;start_VP|VBD|saw;NP|man","cons_2*_1*0=start_S|NP;start_VP|VBD;NP|man","cons_2*_10=start_S|NP;start_VP|VBD|saw;NP|man","cons_2_1*0=start_S|NP|I;start_VP|VBD;NP|man","cons_2*_1*0*=start_S|NP;start_VP|VBD;NP",
-			"cons012=NP|man;IN|with;NP|telescope","cons01*2*=NP|man;IN;NP","cons01*2=NP|man;IN;NP|telescope","cons012*=NP|man;IN|with;NP","cons0*1*2*=NP;IN;NP",
-			"cons_101=start_VP|VBD|saw;NP|man;IN|with","cons_1*01*=start_VP|VBD;NP|man;IN","cons_1*01=start_VP|VBD;NP|man;IN|with","cons_101*=start_VP|VBD|saw;NP|man;IN","cons_1*0*1*=start_VP|VBD;NP;IN"};
-	private String[] build3 = {"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=IN|with","cons1*=IN",
-			"cons2=NP|telescope","cons2*=NP","cons_10=start_S|NP|I;VP|saw","cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP",
-			"cons01=VP|saw;IN|with","cons01*=VP|saw;IN","cons0*1=VP;IN|with","cons0*1*=VP;IN",
-			"cons012=VP|saw;IN|with;NP|telescope","cons01*2*=VP|saw;IN;NP","cons01*2=VP|saw;IN;NP|telescope","cons012*=VP|saw;IN|with;NP","cons0*1*2*=VP;IN;NP",
-			"cons_101=start_S|NP|I;VP|saw;IN|with","cons_1*01*=start_S|NP;VP|saw;IN","cons_1*01=start_S|NP;VP|saw;IN|with","cons_101*=start_S|NP|I;VP|saw;IN","cons_1*0*1*=start_S|NP;VP;IN"};
-	private String[] build4 = {"cons0=IN|with","cons0*=IN","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
-			"cons1=NP|telescope","cons1*=NP","cons_10=start_VP|VP|saw;IN|with","cons_10*=start_VP|VP|saw;IN","cons_1*0=start_VP|VP;IN|with","cons_1*0*=start_VP|VP;IN",
-			"cons01=IN|with;NP|telescope","cons01*=IN|with;NP","cons0*1=IN;NP|telescope","cons0*1*=IN;NP",
-			"cons_2_10=start_S|NP|I;start_VP|VP|saw;IN|with","cons_2*_1*0=start_S|NP;start_VP|VP;IN|with","cons_2*_10=start_S|NP;start_VP|VP|saw;IN|with","cons_2_1*0=start_S|NP|I;start_VP|VP;IN|with","cons_2*_1*0*=start_S|NP;start_VP|VP;IN",
-			"cons_101=start_VP|VP|saw;IN|with;NP|telescope","cons_1*01*=start_VP|VP;IN|with;NP","cons_1*01=start_VP|VP;IN|with;NP|telescope","cons_101*=start_VP|VP|saw;IN|with;NP","cons_1*0*1*=start_VP|VP;IN;NP"};
-	private String[] build5 = {"cons0=NP|telescope","cons0*=NP","cons_1=start_PP|IN|with","cons_1*=start_PP|IN","cons_2=start_VP|VP|saw","cons_2*=start_VP|VP",
-			"cons_10=start_PP|IN|with;NP|telescope","cons_10*=start_PP|IN|with;NP","cons_1*0=start_PP|IN;NP|telescope","cons_1*0*=start_PP|IN;NP","cons_2_10=start_VP|VP|saw;start_PP|IN|with;NP|telescope",
-			"cons_2*_1*0=start_VP|VP;start_PP|IN;NP|telescope","cons_2*_10=start_VP|VP;start_PP|IN|with;NP|telescope","cons_2_1*0=start_VP|VP|saw;start_PP|IN;NP|telescope","cons_2*_1*0*=start_VP|VP;start_PP|IN;NP"};
-	private String[] build6 = {"cons0=PP|with","cons0*=PP","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
-			"cons_10=start_VP|VP|saw;PP|with","cons_10*=start_VP|VP|saw;PP","cons_1*0=start_VP|VP;PP|with","cons_1*0*=start_VP|VP;PP",
-			"cons_2_10=start_S|NP|I;start_VP|VP|saw;PP|with","cons_2*_1*0=start_S|NP;start_VP|VP;PP|with","cons_2*_10=start_S|NP;start_VP|VP|saw;PP|with","cons_2_1*0=start_S|NP|I;start_VP|VP;PP|with","cons_2*_1*0*=start_S|NP;start_VP|VP;PP"};
-	private String[] build7 = {"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons_10=start_S|NP|I;VP|saw",
-			"cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP"};
-	
-	private String[] check0 = {"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|NP|I","checkcons_last*=S|NP",
-			"production=S→NP","surround1=VBD|saw","surround1*=VBD","surround2=DT|the;NN|man","surround2*=DT;NN"};
-	private String[] check1 = {"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|VBD|saw","checkcons_last*=VP|VBD","production=VP→VBD",
-			"surround_1=PRP|I","surround_1*=PRP","surround1=DT|the;NN|man","surround1*=DT;NN","surround2=IN|with","surround2*=IN"};
-	private String[] check2 = {"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|NP|man","checkcons_last*=VP|NP","checkcons_0last=VP|VBD|saw;VP|NP|man",
-			"production=VP→VBD,NP","surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN",
-			"surround2=DT|the;NN|telescope","surround2*=DT;NN"};
-	private String[] check3 = {"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|VP|saw","checkcons_last*=VP|VP","production=VP→VP",
-			"surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN","surround2=DT|the;NN|telescope","surround2*=DT;NN"};
-	private String[] check4 = {"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|IN|with","checkcons_last*=PP|IN","production=PP→IN",
-			"surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN","surround_2=PRP|I","surround_2*=PRP","surround1=DT|the;NN|telescope","surround1*=DT;NN"};
-	private String[] check5 = {"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|NP|telescope","checkcons_last*=PP|NP",
-			"checkcons_0last=PP|IN|with;PP|NP|telescope","production=PP→IN,NP","surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN",
-			"surround_2=PRP|I","surround_2*=PRP"};
-	private String[] check6 = {"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|PP|with","checkcons_last*=VP|PP",
-			"checkcons_0last=VP|VP|saw;VP|PP|with","production=VP→VP,PP","surround_1=PRP|I","surround_1*=PRP"};
-	private String[] check7 = {"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|VP|saw","checkcons_last*=S|VP","checkcons_0last=S|NP|I;S|VP|saw",
-			"production=S→NP,VP"};
+	private List<Event> events ;
+	private AbstractGenerateHeadWords aghw ;
+	private SyntacticAnalysisContextGenerator<HeadTreeNode> generator ;
+	private TreeNode tree ;
+	private HeadTreeNode headTree ;
+	private SyntacticAnalysisSample<HeadTreeNode> sample ;
+	private List<String> words ;
+	private List<HeadTreeNode> chunkTree ;
+	private List<List<HeadTreeNode>> buildAndCheckTree ;
+	private List<String> actions ;
 	
 	@Before
-	public void setUp() throws CloneNotSupportedException, IOException{
-		pgt = new BracketExpUtil();
-		ttht = new TreeToHeadTree();
-		tree = pgt.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
-		headTree = ttht.treeToHeadTree(tree);
-		tta = new HeadTreeToActions();
-		sample = tta.treeToAction(headTree);
+	public void setUp() throws IOException, CloneNotSupportedException{
+		events = new ArrayList<Event>();
+		aghw = new ConcreteGenerateHeadWords();
+		generator = new SyntacticAnalysisContextGeneratorConf();
+		tree = BracketExpUtil.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
+		headTree = TreeToHeadTree.treeToHeadTree(tree,aghw);
+		sample = HeadTreeToActions.headTreeToAction(headTree,aghw);
 		words = sample.getWords();
 		chunkTree = sample.getChunkTree();
 		buildAndCheckTree = sample.getBuildAndCheckTree();
 		actions = sample.getActions();
-		ac = sample.getAdditionalContext();
-		generator = new SyntacticAnalysisContextGeneratorConf();
+		
 		//chunk
 		for (int i = words.size(); i < 2*words.size(); i++) {		
-			String[] context = generator.getContextForChunk(i-words.size(),chunkTree, actions, ac);
-            events.add(new Event(actions.get(i), context));
-		}		
+			String[] context = generator.getContextForChunk(i-words.size(),chunkTree, actions, null);
+		    events.add(new Event(actions.get(i), context));
+		}
+		
 		//buildAndCheck 两个变量i j   i控制第几个list  j控制list中的第几个
 		int j = 0;
 		for (int i = 2*words.size(); i < actions.size(); i=i+2) {
-			String[] buildContext = generator.getContextForBuild(j,buildAndCheckTree.get(i-2*words.size()), actions, ac);
+			String[] buildContext = generator.getContextForBuild(j,buildAndCheckTree.get(i-2*words.size()), actions, null);
 			events.add(new Event(actions.get(i), buildContext));
 			if(actions.get(i+1).equals("yes")){
 				int record = j-1;
@@ -174,11 +69,11 @@ public class SyntacticAnalysisSampleEventTest {
 				j++;
 			}  
 		}
-		//buildAndCheck 两个变量i j   i控制第几个list  j控制list中的第几个
+		
 		j = 0;
 		for (int i = 2*words.size(); i < actions.size(); i=i+2) {    
 			if(actions.get(i+1).equals("yes")){
-				String[] checkContext = generator.getContextForCheck(j,buildAndCheckTree.get(i+1-2*words.size()), actions, ac);
+				String[] checkContext = generator.getContextForCheck(j,buildAndCheckTree.get(i+1-2*words.size()), actions, null);
 				int record = j-1;
 				for (int k = record; k >= 0; k--) {		    
 					if(buildAndCheckTree.get(i-2*words.size()).get(k).getNodeName().split("_")[0].equals("start")){			    
@@ -188,11 +83,54 @@ public class SyntacticAnalysisSampleEventTest {
 				}
 				events.add(new Event(actions.get(i+1), checkContext));
 			}else if(actions.get(i+1).equals("no")){            	
-				String[] checkContext = generator.getContextForCheck(j,buildAndCheckTree.get(i+1-2*words.size()), actions, ac);
+				String[] checkContext = generator.getContextForCheck(j,buildAndCheckTree.get(i+1-2*words.size()), actions, null);
 				events.add(new Event(actions.get(i+1), checkContext));
 				j++;
 			}  
-		}
+		}		
+	}
+	
+	/**
+	 * 对chunk步骤生成的事件进行测试
+	 * @throws CloneNotSupportedException
+	 * @throws IOException
+	 */
+	@Test
+	public void testChunkEvent() throws CloneNotSupportedException, IOException{
+
+		String[] chunk0 = new String[]{"chunkandpostag0=PRP|I","chunkandpostag0*=PRP","chunkandpostag1=VBD|saw","chunkandpostag1*=VBD","chunkandpostag2=DT|the",
+				"chunkandpostag2*=DT","chunkandpostag01=PRP|I;VBD|saw","chunkandpostag01*=PRP|I;VBD","chunkandpostag0*1=PRP;VBD|saw","chunkandpostag0*1*=PRP;VBD"};
+		String[] chunk1 = new String[]{"chunkandpostag0=VBD|saw","chunkandpostag0*=VBD","chunkandpostag_1=start_NP|PRP|I","chunkandpostag_1*=start_NP|PRP","chunkandpostag1=DT|the",
+				"chunkandpostag1*=DT","chunkandpostag2=NN|man","chunkandpostag2*=NN","chunkandpostag_10=start_NP|PRP|I;VBD|saw","chunkandpostag_10*=start_NP|PRP|I;VBD",
+				"chunkandpostag_1*0=start_NP|PRP;VBD|saw","chunkandpostag_1*0*=start_NP|PRP;VBD","chunkandpostag01=VBD|saw;DT|the",
+				"chunkandpostag01*=VBD|saw;DT","chunkandpostag0*1=VBD;DT|the","chunkandpostag0*1*=VBD;DT"};
+		String[] chunk2 = new String[]{"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|VBD|saw","chunkandpostag_1*=other|VBD","chunkandpostag_2=start_NP|PRP|I",
+				"chunkandpostag_2*=start_NP|PRP","chunkandpostag1=NN|man","chunkandpostag1*=NN","chunkandpostag2=IN|with","chunkandpostag2*=IN",
+				"chunkandpostag_10=other|VBD|saw;DT|the","chunkandpostag_10*=other|VBD|saw;DT","chunkandpostag_1*0=other|VBD;DT|the","chunkandpostag_1*0*=other|VBD;DT",
+				"chunkandpostag01=DT|the;NN|man","chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|man","chunkandpostag0*1*=DT;NN"};
+		String[] chunk5 = new String[]{"chunkandpostag0=DT|the","chunkandpostag0*=DT","chunkandpostag_1=other|IN|with","chunkandpostag_1*=other|IN","chunkandpostag_2=join_NP|NN|man",
+				"chunkandpostag_2*=join_NP|NN","chunkandpostag1=NN|telescope","chunkandpostag1*=NN","chunkandpostag_10=other|IN|with;DT|the","chunkandpostag_10*=other|IN|with;DT",
+				"chunkandpostag_1*0=other|IN;DT|the","chunkandpostag_1*0*=other|IN;DT","chunkandpostag01=DT|the;NN|telescope",
+				"chunkandpostag01*=DT|the;NN","chunkandpostag0*1=DT;NN|telescope","chunkandpostag0*1*=DT;NN"};
+		String[] chunk4 = new String[]{"chunkandpostag0=IN|with","chunkandpostag0*=IN","chunkandpostag_1=join_NP|NN|man","chunkandpostag_1*=join_NP|NN","chunkandpostag_2=start_NP|DT|the",
+				"chunkandpostag_2*=start_NP|DT","chunkandpostag1=DT|the","chunkandpostag1*=DT","chunkandpostag2=NN|telescope","chunkandpostag2*=NN",
+				"chunkandpostag_10=join_NP|NN|man;IN|with","chunkandpostag_10*=join_NP|NN|man;IN","chunkandpostag_1*0=join_NP|NN;IN|with","chunkandpostag_1*0*=join_NP|NN;IN",
+				"chunkandpostag01=IN|with;DT|the","chunkandpostag01*=IN|with;DT","chunkandpostag0*1=IN;DT|the","chunkandpostag0*1*=IN;DT"};
+		String[] chunk3 = new String[]{"chunkandpostag0=NN|man","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT",
+				"chunkandpostag_2=other|VBD|saw","chunkandpostag_2*=other|VBD","chunkandpostag1=IN|with","chunkandpostag1*=IN",
+				"chunkandpostag2=DT|the","chunkandpostag2*=DT",
+				"chunkandpostag_10=start_NP|DT|the;NN|man","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|man","chunkandpostag_1*0*=start_NP|DT;NN",
+				"chunkandpostag01=NN|man;IN|with","chunkandpostag01*=NN|man;IN","chunkandpostag0*1=NN;IN|with","chunkandpostag0*1*=NN;IN"};
+		String[] chunk6 = new String[]{"chunkandpostag0=NN|telescope","chunkandpostag0*=NN","chunkandpostag_1=start_NP|DT|the","chunkandpostag_1*=start_NP|DT","chunkandpostag_2=other|IN|with",
+				"chunkandpostag_2*=other|IN","chunkandpostag_10=start_NP|DT|the;NN|telescope","chunkandpostag_10*=start_NP|DT|the;NN","chunkandpostag_1*0=start_NP|DT;NN|telescope","chunkandpostag_1*0*=start_NP|DT;NN"};
+				
+		List<Event> event1 = new ArrayList<>();
+		List<Event> event2 = new ArrayList<>();
+		List<Event> event3 = new ArrayList<>();
+		List<Event> event4 = new ArrayList<>();
+		List<Event> event5 = new ArrayList<>();
+		List<Event> event6 = new ArrayList<>();
+		List<Event> event7 = new ArrayList<>();
 		
 		event1.add(new Event("start_NP",chunk0));
 		event2.add(new Event("other",chunk1));
@@ -201,6 +139,65 @@ public class SyntacticAnalysisSampleEventTest {
 		event5.add(new Event("other",chunk4));
 		event6.add(new Event("start_NP",chunk5));
 		event7.add(new Event("join_NP",chunk6));
+				
+		assertEquals(events.get(0).toString(),event1.get(0).toString());
+		assertEquals(events.get(1).toString(),event2.get(0).toString());
+		assertEquals(events.get(2).toString(),event3.get(0).toString());
+		assertEquals(events.get(3).toString(),event4.get(0).toString());
+		assertEquals(events.get(4).toString(),event5.get(0).toString());
+		assertEquals(events.get(5).toString(),event6.get(0).toString());
+		assertEquals(events.get(6).toString(),event7.get(0).toString());
+	}
+	
+	/**
+	 * 对build步骤生成的事件进行测试
+	 */
+	@Test
+	public void testBuildEvent(){
+
+		String[] build0 = new String[]{"cons0=NP|I","cons0*=NP","cons1=VBD|saw","cons1*=VBD","cons2=NP|man","cons2*=NP",
+				"cons01=NP|I;VBD|saw","cons01*=NP|I;VBD","cons0*1=NP;VBD|saw","cons0*1*=NP;VBD",
+				"cons012=NP|I;VBD|saw;NP|man","cons01*2*=NP|I;VBD;NP","cons01*2=NP|I;VBD;NP|man","cons012*=NP|I;VBD|saw;NP","cons0*1*2*=NP;VBD;NP"};
+		String[] build1 = new String[]{"cons0=VBD|saw","cons0*=VBD","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=NP|man","cons1*=NP",
+				"cons2=IN|with","cons2*=IN","cons_10=start_S|NP|I;VBD|saw","cons_10*=start_S|NP|I;VBD","cons_1*0=start_S|NP;VBD|saw","cons_1*0*=start_S|NP;VBD",
+				"cons01=VBD|saw;NP|man","cons01*=VBD|saw;NP","cons0*1=VBD;NP|man","cons0*1*=VBD;NP",
+				"cons012=VBD|saw;NP|man;IN|with","cons01*2*=VBD|saw;NP;IN","cons01*2=VBD|saw;NP;IN|with","cons012*=VBD|saw;NP|man;IN","cons0*1*2*=VBD;NP;IN",
+				"cons_101=start_S|NP|I;VBD|saw;NP|man","cons_1*01*=start_S|NP;VBD|saw;NP","cons_1*01=start_S|NP;VBD|saw;NP|man","cons_101*=start_S|NP|I;VBD|saw;NP","cons_1*0*1*=start_S|NP;VBD;NP"};
+		String[] build2 = new String[]{"cons0=NP|man","cons0*=NP","cons_1=start_VP|VBD|saw","cons_1*=start_VP|VBD","cons_2=start_S|NP|I","cons_2*=start_S|NP",
+				"cons1=IN|with","cons1*=IN","cons2=NP|telescope","cons2*=NP",
+				"cons_10=start_VP|VBD|saw;NP|man","cons_10*=start_VP|VBD|saw;NP","cons_1*0=start_VP|VBD;NP|man","cons_1*0*=start_VP|VBD;NP",
+				"cons01=NP|man;IN|with","cons01*=NP|man;IN","cons0*1=NP;IN|with","cons0*1*=NP;IN",
+				"cons_2_10=start_S|NP|I;start_VP|VBD|saw;NP|man","cons_2*_1*0=start_S|NP;start_VP|VBD;NP|man","cons_2*_10=start_S|NP;start_VP|VBD|saw;NP|man","cons_2_1*0=start_S|NP|I;start_VP|VBD;NP|man","cons_2*_1*0*=start_S|NP;start_VP|VBD;NP",
+				"cons012=NP|man;IN|with;NP|telescope","cons01*2*=NP|man;IN;NP","cons01*2=NP|man;IN;NP|telescope","cons012*=NP|man;IN|with;NP","cons0*1*2*=NP;IN;NP",
+				"cons_101=start_VP|VBD|saw;NP|man;IN|with","cons_1*01*=start_VP|VBD;NP|man;IN","cons_1*01=start_VP|VBD;NP|man;IN|with","cons_101*=start_VP|VBD|saw;NP|man;IN","cons_1*0*1*=start_VP|VBD;NP;IN"};
+		String[] build3 = new String[]{"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons1=IN|with","cons1*=IN",
+				"cons2=NP|telescope","cons2*=NP","cons_10=start_S|NP|I;VP|saw","cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP",
+				"cons01=VP|saw;IN|with","cons01*=VP|saw;IN","cons0*1=VP;IN|with","cons0*1*=VP;IN",
+				"cons012=VP|saw;IN|with;NP|telescope","cons01*2*=VP|saw;IN;NP","cons01*2=VP|saw;IN;NP|telescope","cons012*=VP|saw;IN|with;NP","cons0*1*2*=VP;IN;NP",
+				"cons_101=start_S|NP|I;VP|saw;IN|with","cons_1*01*=start_S|NP;VP|saw;IN","cons_1*01=start_S|NP;VP|saw;IN|with","cons_101*=start_S|NP|I;VP|saw;IN","cons_1*0*1*=start_S|NP;VP;IN"};
+		String[] build4 = new String[]{"cons0=IN|with","cons0*=IN","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
+				"cons1=NP|telescope","cons1*=NP","cons_10=start_VP|VP|saw;IN|with","cons_10*=start_VP|VP|saw;IN","cons_1*0=start_VP|VP;IN|with","cons_1*0*=start_VP|VP;IN",
+				"cons01=IN|with;NP|telescope","cons01*=IN|with;NP","cons0*1=IN;NP|telescope","cons0*1*=IN;NP",
+				"cons_2_10=start_S|NP|I;start_VP|VP|saw;IN|with","cons_2*_1*0=start_S|NP;start_VP|VP;IN|with","cons_2*_10=start_S|NP;start_VP|VP|saw;IN|with","cons_2_1*0=start_S|NP|I;start_VP|VP;IN|with","cons_2*_1*0*=start_S|NP;start_VP|VP;IN",
+				"cons_101=start_VP|VP|saw;IN|with;NP|telescope","cons_1*01*=start_VP|VP;IN|with;NP","cons_1*01=start_VP|VP;IN|with;NP|telescope","cons_101*=start_VP|VP|saw;IN|with;NP","cons_1*0*1*=start_VP|VP;IN;NP"};
+		String[] build5 = new String[]{"cons0=NP|telescope","cons0*=NP","cons_1=start_PP|IN|with","cons_1*=start_PP|IN","cons_2=start_VP|VP|saw","cons_2*=start_VP|VP",
+				"cons_10=start_PP|IN|with;NP|telescope","cons_10*=start_PP|IN|with;NP","cons_1*0=start_PP|IN;NP|telescope","cons_1*0*=start_PP|IN;NP","cons_2_10=start_VP|VP|saw;start_PP|IN|with;NP|telescope",
+				"cons_2*_1*0=start_VP|VP;start_PP|IN;NP|telescope","cons_2*_10=start_VP|VP;start_PP|IN|with;NP|telescope","cons_2_1*0=start_VP|VP|saw;start_PP|IN;NP|telescope","cons_2*_1*0*=start_VP|VP;start_PP|IN;NP"};
+		String[] build6 = new String[]{"cons0=PP|with","cons0*=PP","cons_1=start_VP|VP|saw","cons_1*=start_VP|VP","cons_2=start_S|NP|I","cons_2*=start_S|NP",
+				"cons_10=start_VP|VP|saw;PP|with","cons_10*=start_VP|VP|saw;PP","cons_1*0=start_VP|VP;PP|with","cons_1*0*=start_VP|VP;PP",
+				"cons_2_10=start_S|NP|I;start_VP|VP|saw;PP|with","cons_2*_1*0=start_S|NP;start_VP|VP;PP|with","cons_2*_10=start_S|NP;start_VP|VP|saw;PP|with","cons_2_1*0=start_S|NP|I;start_VP|VP;PP|with","cons_2*_1*0*=start_S|NP;start_VP|VP;PP"};
+		String[] build7 = new String[]{"cons0=VP|saw","cons0*=VP","cons_1=start_S|NP|I","cons_1*=start_S|NP","cons_10=start_S|NP|I;VP|saw",
+				"cons_10*=start_S|NP|I;VP","cons_1*0=start_S|NP;VP|saw","cons_1*0*=start_S|NP;VP"};
+		
+		List<Event> event8 = new ArrayList<>();
+		List<Event> event9 = new ArrayList<>();
+		List<Event> event10 = new ArrayList<>();
+		List<Event> event11 = new ArrayList<>();
+		List<Event> event12 = new ArrayList<>();
+		List<Event> event13 = new ArrayList<>();
+		List<Event> event14 = new ArrayList<>();
+		List<Event> event15 = new ArrayList<>();
+				
 		event8.add(new Event("start_S",build0));
 		event9.add(new Event("start_VP",build1));
 		event10.add(new Event("join_VP",build2));
@@ -209,25 +206,7 @@ public class SyntacticAnalysisSampleEventTest {
 		event13.add(new Event("join_PP",build5));
 		event14.add(new Event("join_VP",build6));
 		event15.add(new Event("join_S",build7));
-		event16.add(new Event("no",check0));
-		event17.add(new Event("no",check1));
-		event18.add(new Event("yes",check2));
-		event19.add(new Event("no",check3));
-		event20.add(new Event("no",check4));
-		event21.add(new Event("yes",check5));
-		event22.add(new Event("yes",check6));
-		event23.add(new Event("yes",check7));
-	}
-	
-	@Test
-	public void test(){
-		assertEquals(events.get(0).toString(),event1.get(0).toString());
-		assertEquals(events.get(1).toString(),event2.get(0).toString());
-		assertEquals(events.get(2).toString(),event3.get(0).toString());
-		assertEquals(events.get(3).toString(),event4.get(0).toString());
-		assertEquals(events.get(4).toString(),event5.get(0).toString());
-		assertEquals(events.get(5).toString(),event6.get(0).toString());
-		assertEquals(events.get(6).toString(),event7.get(0).toString());
+				
 		assertEquals(events.get(7).toString(),event8.get(0).toString());
 		assertEquals(events.get(8).toString(),event9.get(0).toString());
 		assertEquals(events.get(9).toString(),event10.get(0).toString());
@@ -236,7 +215,51 @@ public class SyntacticAnalysisSampleEventTest {
 		assertEquals(events.get(12).toString(),event13.get(0).toString());
 		assertEquals(events.get(13).toString(),event14.get(0).toString());
 		assertEquals(events.get(14).toString(),event15.get(0).toString());
-		assertEquals(events.get(15).toString(),event16.get(0).toString());
+	}
+	
+	/**
+	 * 对check步骤生成的事件进行测试
+	 */
+	@Test
+	public void testCheckEvent(){
+
+		String[] check0 = new String[]{"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|NP|I","checkcons_last*=S|NP",
+				"production=S→NP","surround1=VBD|saw","surround1*=VBD","surround2=DT|the;NN|man","surround2*=DT;NN"};
+		String[] check1 = new String[]{"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|VBD|saw","checkcons_last*=VP|VBD","production=VP→VBD",
+				"surround_1=PRP|I","surround_1*=PRP","surround1=DT|the;NN|man","surround1*=DT;NN","surround2=IN|with","surround2*=IN"};
+		String[] check2 = new String[]{"checkcons_begin=VP|VBD|saw","checkcons_begin*=VP|VBD","checkcons_last=VP|NP|man","checkcons_last*=VP|NP","checkcons_0last=VP|VBD|saw;VP|NP|man",
+				"production=VP→VBD,NP","surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN",
+				"surround2=DT|the;NN|telescope","surround2*=DT;NN"};
+		String[] check3 = new String[]{"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|VP|saw","checkcons_last*=VP|VP","production=VP→VP",
+				"surround_1=PRP|I","surround_1*=PRP","surround1=IN|with","surround1*=IN","surround2=DT|the;NN|telescope","surround2*=DT;NN"};
+		String[] check4 = new String[]{"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|IN|with","checkcons_last*=PP|IN","production=PP→IN",
+				"surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN","surround_2=PRP|I","surround_2*=PRP","surround1=DT|the;NN|telescope","surround1*=DT;NN"};
+		String[] check5 = new String[]{"checkcons_begin=PP|IN|with","checkcons_begin*=PP|IN","checkcons_last=PP|NP|telescope","checkcons_last*=PP|NP",
+				"checkcons_0last=PP|IN|with;PP|NP|telescope","production=PP→IN,NP","surround_1=VBD|saw;DT|the;NN|man","surround_1*=VBD;DT;NN",
+				"surround_2=PRP|I","surround_2*=PRP"};
+		String[] check6 = new String[]{"checkcons_begin=VP|VP|saw","checkcons_begin*=VP|VP","checkcons_last=VP|PP|with","checkcons_last*=VP|PP",
+				"checkcons_0last=VP|VP|saw;VP|PP|with","production=VP→VP,PP","surround_1=PRP|I","surround_1*=PRP"};
+		String[] check7 = new String[]{"checkcons_begin=S|NP|I","checkcons_begin*=S|NP","checkcons_last=S|VP|saw","checkcons_last*=S|VP","checkcons_0last=S|NP|I;S|VP|saw",
+				"production=S→NP,VP"};
+		
+		List<Event> event16 = new ArrayList<>();
+		List<Event> event17 = new ArrayList<>();
+		List<Event> event18 = new ArrayList<>();
+		List<Event> event19 = new ArrayList<>();
+		List<Event> event20 = new ArrayList<>();
+		List<Event> event21 = new ArrayList<>();
+		List<Event> event22 = new ArrayList<>();
+		List<Event> event23 = new ArrayList<>();
+		
+		event16.add(new Event("no",check0));
+		event17.add(new Event("no",check1));
+		event18.add(new Event("yes",check2));
+		event19.add(new Event("no",check3));
+		event20.add(new Event("no",check4));
+		event21.add(new Event("yes",check5));
+		event22.add(new Event("yes",check6));
+		event23.add(new Event("yes",check7));
+
 		assertEquals(events.get(16).toString(),event17.get(0).toString());
 		assertEquals(events.get(17).toString(),event18.get(0).toString());
 		assertEquals(events.get(18).toString(),event19.get(0).toString());

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/Tree2Action2TreeTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/Tree2Action2TreeTest.java
@@ -2,62 +2,24 @@ package com.lc.nlp4han.constituent.maxent;
 
 import static org.junit.Assert.*;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.lc.nlp4han.constituent.BracketExpUtil;
 import com.lc.nlp4han.constituent.HeadTreeNode;
-import com.lc.nlp4han.constituent.PlainTextByTreeStream;
 import com.lc.nlp4han.constituent.TreeNode;
-import com.lc.nlp4han.ml.util.FileInputStreamFactory;
 
 
 /**
- * 测试树到动作再到树是否合法
+ * 测试句法树转换成动作序列，再将动作序列转换成句法树，比较原句法树和转换得到的句法树是否一致
  * @author 王馨苇
  *
  */
 public class Tree2Action2TreeTest{
 
-	private URL is;
-	private PlainTextByTreeStream lineStream ;
-	private String txt ;
-	private BracketExpUtil pgt ;
-	private TreeToHeadTree ttht;
-	private TreeNode tree ;
-    private HeadTreeNode headTree;
-	private HeadTreeToActions tta ;
-	private SyntacticAnalysisSample<HeadTreeNode> sample ;
-	private List<String> words ;
-	private List<String> actions ;
-
-	private ActionsToTree att ;
-	private TreeNode newTree ;
-	
-	@Before
-	public void setUP() throws UnsupportedOperationException, FileNotFoundException, IOException, CloneNotSupportedException{
-		is = Tree2Action2TreeTest.class.getClassLoader().getResource("com/lc/nlp4han/constituent/maxent/wsj_0015new.mrg");
-		lineStream = new PlainTextByTreeStream(new FileInputStreamFactory(new File(is.getFile())), "utf8");
-		txt = lineStream.read();
-		pgt = new BracketExpUtil();
-		ttht = new TreeToHeadTree();
-		tree = pgt.generateTree(txt);
-        headTree = ttht.treeToHeadTree(tree);
-		tta = new HeadTreeToActions();
-		sample = tta.treeToAction(headTree);
-		words = sample.getWords();
-		actions = sample.getActions();
-
-		att = new ActionsToTree();
-		newTree = att.actionsToTree(words, actions);
-	}
-	
 	/**
 	 * 测试由句法树到动作序列，再从动作序列到句法树的过程
 	 * @throws FileNotFoundException
@@ -66,7 +28,21 @@ public class Tree2Action2TreeTest{
 	 */
 	@Test
 	public void testTreeToActions() throws FileNotFoundException, IOException, CloneNotSupportedException{
-		assertEquals(tree, newTree);
-	}	
-	
+		
+		AbstractGenerateHeadWords aghw = new ConcreteGenerateHeadWords();
+		//节点有多个子节点
+		//1 一个子节点 
+		//2 两个子节点
+		//3  大于两个子节点
+		String treestr = "((S(NP(NNP Mr.)(NNP Vinken))(VP(VBZ is)(NP(NP(NN chairman))(PP(IN of) "
+				+ "(NP(NP(NNP Elsevier)(NNP N.V.))(, ,)"
+				+ "(NP(DT the)(NNP Dutch)(VBG publishing)(NN group))))))(. .)))";
+		TreeNode tree = BracketExpUtil.generateTree(treestr);
+		HeadTreeNode headTree = TreeToHeadTree.treeToHeadTree(tree,aghw);		
+		SyntacticAnalysisSample<HeadTreeNode> sample = HeadTreeToActions.headTreeToAction(headTree,aghw);
+		List<String>words = sample.getWords();
+		List<String>actions = sample.getActions();
+		TreeNode resulttree = ActionsToTree.actionsToTree(words, actions); 
+		assertEquals(tree, resulttree);
+	}		
 }

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/TreePreTreatmentTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/TreePreTreatmentTest.java
@@ -2,78 +2,87 @@ package com.lc.nlp4han.constituent.maxent;
 
 import static org.junit.Assert.*;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.lc.nlp4han.constituent.BracketExpUtil;
-import com.lc.nlp4han.constituent.PlainTextByTreeStream;
 import com.lc.nlp4han.constituent.TreeNode;
-import com.lc.nlp4han.ml.util.FileInputStreamFactory;
 
 /**
- * 预处理操作的测试
+ * 句法树预处理操作的测试
+ * 说明：预处理指的是去掉空节点，和去掉功能标记
  * @author 王馨苇
  *
  */
 public class TreePreTreatmentTest{
 
-	private PlainTextByTreeStream lineStream = null;
-	private PlainTextByTreeStream lineStreamnew = null;
-	private URL url1;
-	private URL url2 ;
-	private String tree = "";
-	private BracketExpUtil pgt ;
-	private String after = "";
-	private String begin = "";
-	private String line = "";
-	
-	@Before
-	public void setUP() throws UnsupportedOperationException, FileNotFoundException, IOException{
-		pgt = new BracketExpUtil();	
-		url1 = TreePreTreatmentTest.class.getClassLoader().getResource("com/lc/nlp4han/constituent/maxent/wsj_0015.mrg");
-		url2 = TreePreTreatmentTest.class.getClassLoader().getResource("com/lc/nlp4han/constituent/maxent/wsj_0015new.mrg");
-		lineStream = new PlainTextByTreeStream(new FileInputStreamFactory(new File(url1.getFile())), "utf8");
-		lineStreamnew = new PlainTextByTreeStream(new FileInputStreamFactory(new File(url2.getFile())), "utf8");
-	}
-	
 	/**
-	 * 验证去除空节点后输出的带换行的括号表达式是否正确
+	 * 验证去除空节点和功能标记后输出的带换行的括号表达式是否正确
 	 * @throws UnsupportedOperationException
 	 * @throws FileNotFoundException
 	 * @throws IOException
 	 */
 	@Test
 	public void testPreTreatment() throws UnsupportedOperationException, FileNotFoundException, IOException{
+		//测试用例：
+		//(1)节点下只有一个子节点，且该子节点是空节点:节点和节点的子节点一起删除
+		String treestr1 = "((S(NP-SBJ-17(NP(DT The)(ADJP(QP($ $)(CD 2.5)(CD billion))(-NONE- *U*))(NNP Byron)(CD 1)(NN plant))"
+				+ "(PP-LOC(IN near)(NP(NP(NNP Rockford))(, ,)(NP(NNP Ill.))(, ,))))(VP(VBD was)(VP(VBN completed)"
+				+ "(NP(-NONE- *-17))(PP-TMP(IN in)(NP(CD 1985)))))(. .)))";
+		TreeNode tree1 = BracketExpUtil.generateTree(treestr1);
+		TreePreTreatment.travelTree(tree1);
+		String result1 = "(S(NP(NP(DT The)(QP($ $)(CD 2.5)(CD billion))(NNP Byron)(CD 1)(NN plant))"
+				+ "(PP(IN near)(NP(NP(NNP Rockford))(, ,)(NP(NNP Ill.))(, ,))))(VP(VBD was)(VP(VBN completed)"
+				+ "(PP(IN in)(NP(CD 1985)))))(. .))";
+		//(2)节点下有多个节点，多个节点中只有一个节点是空节点
+		//2.1多个节点是两个节点，删除空节点，且上提
+		//2.2多个节点大于2，删除空节点，不用上提
+		String treestr2 = "((S(PP(IN For)(NP(CD 1988)))(, ,)(NP-SBJ(NNP Commonwealth)(NNP Edison))(VP(VBD reported)"
+		+"(NP(NP(NNS earnings))(PP(IN of)(NP(NP(QP($ $)(CD 737.5)(CD million))(-NONE- *U*))(, ,)"
+		+ "(CC or)(NP(NP($ $)(CD 3.01)(-NONE- *U*))(NP-ADV(DT a)(NN share)))))))(. .)))";
+		TreeNode tree2 = BracketExpUtil.generateTree(treestr2);
+		TreePreTreatment.travelTree(tree2);
+		String result2 = "(S(PP(IN For)(NP(CD 1988)))(, ,)(NP(NNP Commonwealth)(NNP Edison))(VP(VBD reported)"
+				+"(NP(NP(NNS earnings))(PP(IN of)(NP(QP($ $)(CD 737.5)(CD million))(, ,)"
+				+ "(CC or)(NP(NP($ $)(CD 3.01))(NP(DT a)(NN share)))))))(. .))";
+		//(3)节点下有多个子节点，且多个子节点都是空节点：节点和所有的子节点一起删除
+		String treestr3 = "((S(S-TPC-1(SBAR-TMP(IN Until)(S(NP-SBJ(NNP Congress))(VP(VBZ acts))))(, ,)(NP-SBJ(DT the)(NN government))"
+				+ "(VP(VBZ has)(RB n't)(NP(DT any)(NN authority)(S(NP-SBJ(-NONE- *))(VP(TO to)(VP(VB issue)(NP(NP(JJ new)(NN debt)(NNS obligations))"
+				+ "(PP(IN of)(NP(DT any)(NN kind))))))))))(, ,)(NP-SBJ(DT the)(NNP Treasury))(VP(VBD said)(SBAR(-NONE- 0)(S(-NONE- *T*-1))))(. .)))";
+		TreeNode tree3 = BracketExpUtil.generateTree(treestr3);
+		TreePreTreatment.travelTree(tree3);
+		String result3 = "(S(S(SBAR(IN Until)(S(NP(NNP Congress))(VP(VBZ acts))))(, ,)(NP(DT the)(NN government))"
+				+ "(VP(VBZ has)(RB n't)(NP(DT any)(NN authority)(VP(TO to)(VP(VB issue)(NP(NP(JJ new)(NN debt)(NNS obligations))"
+				+ "(PP(IN of)(NP(DT any)(NN kind)))))))))(, ,)(NP(DT the)(NNP Treasury))(VBD said)(. .))";
+		//(4)功能标记
+		//4.1正常类型的标记：标记-功能标记-数字索引，此时只保留标记的部分
+		//              标记-数字索引，此时保留标记
+		//              标记-功能标记，此时保留标记
+		//4.2功能标记是-LRB-或者是-RRB-，不能像(4)一样处理，要全部保留
+		String treestr4 = "((S(ADVP-TMP(RB Then))(, ,)(SBAR-ADV(RB just)(IN as)(S(NP-SBJ-72(DT the)(NNP Tramp))(VP(VBZ is)"
+				+ "(VP(VBN given)(NP(-NONE- *-72))(NP(NP(DT a)(JJ blind)(NN girl))(SBAR(WHNP-2(-NONE- 0))(S(NP-SBJ(-NONE- *))"
+				+ "(VP(TO to)(VP(VB cure)(NP(-NONE- *T*-2)))))))(PP-LOC(IN in)(`` ``)(NP-TTL(NNP City)(NNP Lights)))))))(, ,)"
+				+ "('' '')(NP-SBJ-73(DT the)(NNP Artist))(VP(VBZ is)(VP(VBN put)(NP(-NONE- *-73))(PP-PUT(IN in)(NP"
+				+ "(NP(NN charge))(PP(IN of)(S-NOM(NP-SBJ(-NONE- *-73))(VP(VBG returning)(NP(NP(DT a)(JJ two-year-old)(NN waif))"
+				+ "(PRN(-LRB- -LRB-)(NP(NNP Nicole)(NNP Alysia))(-RRB- -RRB-))(, ,)(SBAR(WHNP-1(WP$ whose)(NP(NN father)))"
+				+ "(S(NP-SBJ-74(-NONE- *T*-1))(VP(VBZ has)(VP(VBN been)(VP(VBN murdered)(NP(-NONE- *-74))(PP(IN by)"
+				+ "(NP-LGS(NNS thugs))))))))(, ,))(PP-CLR(TO to)(NP(PRP$ her)(NN mother))))))))))(. .)))";
+		TreeNode tree4 = BracketExpUtil.generateTree(treestr4);
+		TreePreTreatment.travelTree(tree4);
+		String result4 = "(S(ADVP(RB Then))(, ,)(SBAR(RB just)(IN as)(S(NP(DT the)(NNP Tramp))(VP(VBZ is)"
+				+ "(VP(VBN given)(NP(NP(DT a)(JJ blind)(NN girl))"
+				+ "(VP(TO to)(VB cure)))(PP(IN in)(`` ``)(NP(NNP City)(NNP Lights)))))))(, ,)"
+				+ "('' '')(NP(DT the)(NNP Artist))(VP(VBZ is)(VP(VBN put)(PP(IN in)(NP"
+				+ "(NP(NN charge))(PP(IN of)(VP(VBG returning)(NP(NP(DT a)(JJ two-year-old)(NN waif))"
+				+ "(PRN(-LRB- -LRB-)(NP(NNP Nicole)(NNP Alysia))(-RRB- -RRB-))(, ,)(SBAR(WHNP(WP$ whose)(NP(NN father)))"
+				+ "(VP(VBZ has)(VP(VBN been)(VP(VBN murdered)(PP(IN by)"
+				+ "(NP(NNS thugs)))))))(, ,))(PP(TO to)(NP(PRP$ her)(NN mother)))))))))(. .))";
 		
-		while((tree = lineStream.read()) != ""){
-			TreeNode node = pgt.generateTree(tree);
-			//对树进行遍历
-			TreePreTreatment.travelTree(node);
-			String newStr = node.toNoNoneBracket();
-			TreeNode newTree = pgt.generateTree("("+newStr+")");
-			String oneTree = "";
-			String[] str = ("("+TreeNode.printTree(newTree, 1)+")").split("\n");
-			for (int i = 0; i < str.length; i++) {
-				oneTree += str[i].trim();
-			}
-			begin += pgt.format(oneTree)+"\n";
-		}
-		while((line = lineStreamnew.read()) != ""){
-			line = pgt.format(line)+"\n";
-			after += line;
-		}
-		assertEquals(begin,after);
-	}
-	
-	@After
-	public void tearDown() throws IOException{
-		lineStream.close();
-		lineStreamnew.close();
+		assertEquals(result1,tree1.toNoNoneBracket());	
+		assertEquals(result2,tree2.toNoNoneBracket());	
+		assertEquals(result3,tree3.toNoNoneBracket());	
+		assertEquals(result4,tree4.toNoNoneBracket());	
 	}
 }

--- a/src/test/java/com/lc/nlp4han/constituent/maxent/TreeToEvalStructureTest.java
+++ b/src/test/java/com/lc/nlp4han/constituent/maxent/TreeToEvalStructureTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.lc.nlp4han.constituent.BracketExpUtil;
@@ -21,27 +20,14 @@ import com.lc.nlp4han.constituent.TreeToEvalStructure;
  */
 public class TreeToEvalStructureTest {
 
-	private BracketExpUtil pgt;
-	private TreeNode tree1;
-	private List<EvalStructure> pre1;
-	private List<EvalStructure> result1;
-	private TreeToEvalStructure ttn1;
-	private TreeToEvalStructure ttn2;
-	private TreeNode tree2;
-	private List<EvalStructure> result2;
-	private List<EvalStructure> pre2;
-
-	@Before
-	public void setUp() throws CloneNotSupportedException{
-		pgt = new BracketExpUtil();
-		ttn1 = new TreeToEvalStructure();
-		ttn2 = new TreeToEvalStructure();
-		result1 = new ArrayList<>();
-		result2 = new ArrayList<>();
-		tree1 = pgt.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
-		tree2 = pgt.generateTree("((S(NP(EX There))(VP(VBZ is)(NP(DT no)(NN box))(PP(IN in)(NP(PRP$ our)(NNS box)))(ADVP (RB now)))(. .)('' '') ))");
-		pre1 = ttn1.getNonterminalAndSpan(tree1);
-		pre2 = ttn2.getNonterminalAndSpan(tree2);
+	@Test
+	public void testTreeToEvalStructure() throws CloneNotSupportedException{
+		TreeNode tree1 = BracketExpUtil.generateTree("((S(NP(PRP I))(VP(VP(VBD saw)(NP(DT the)(NN man)))(PP(IN with)(NP(DT the)(NN telescope))))))");
+		TreeNode tree2 = BracketExpUtil.generateTree("((S(NP(EX There))(VP(VBZ is)(NP(DT no)(NN box))(PP(IN in)(NP(PRP$ our)(NNS box)))(ADVP (RB now)))(. .)('' '') ))");
+		List<EvalStructure> pre1 = TreeToEvalStructure.getNonterminalAndSpan(tree1);
+		List<EvalStructure> pre2 = TreeToEvalStructure.getNonterminalAndSpan(tree2);
+		
+		List<EvalStructure> result1 = new ArrayList<>(); 
 		result1.add(new EvalStructure("NP", 0, 1));
 		result1.add(new EvalStructure("NP", 2, 4));
 		result1.add(new EvalStructure("VP", 1, 4));
@@ -50,6 +36,7 @@ public class TreeToEvalStructureTest {
 		result1.add(new EvalStructure("VP", 1, 7));
 		result1.add(new EvalStructure("S", 0, 7));
 		
+		List<EvalStructure> result2 = new ArrayList<>(); 
 		result2.add(new EvalStructure("NP", 0,1));
 		result2.add(new EvalStructure("NP", 2, 4));
 		result2.add(new EvalStructure("NP", 5, 7));
@@ -57,12 +44,7 @@ public class TreeToEvalStructureTest {
 		result2.add(new EvalStructure("ADVP", 7, 8));
 		result2.add(new EvalStructure("VP", 1, 8));
 		result2.add(new EvalStructure("S", 0, 10));
-	}
-	
-	@Test
-	public void testTreeToEvalStructure(){
 		assertEquals(pre1.toString(),result1.toString());
 		assertEquals(pre2.toString(),result2.toString());
-		System.out.println(tree1);
 	}
 }


### PR DESCRIPTION
1. 去掉生成头结点模板，将实现头结点的方法改为在运行类中指定
2. 改动单元测试代码，将一些全局变量改为局部变量
3. 模板类中的方法改为protected，将一些公有方法改为私有方法
4. 将对树的操作类TreeToHeadTree，ActionsToTree，HeadTreeToActions下的方法改为静态的工具类方法
5. 将ActionsToTree，HeadTreeToActions下的combine方法提取到ChunkTreeCombineUtil下
，