### PR TITLE
 增加输出Stanford样式文本的方法，增加解析Stanford语料的解析类

### DIFF
--- a/src/main/java/com/lc/nlp4han/dependency/DependencySample.java
+++ b/src/main/java/com/lc/nlp4han/dependency/DependencySample.java
@@ -22,9 +22,16 @@ public class DependencySample {
 	private List<String> dependencyIndices;
 	private String[][] adtionalContext;
 	
-	public DependencySample(List<String> words,List<String> pos){
-		this.words = words;
-		this.pos = pos;
+	/**
+	 * 构造
+	 * @param words 词语
+	 * @param pos 词性
+	 * @param dependency 依存关系
+	 * @param dependencyWords 依存关系对应的词
+	 * @param dependencyIndices 依存关系对应的词的下标
+	 */
+	public DependencySample(String[] words, String[] pos, String[] dependency, String[] dependencyWords, String[] dependencyIndices){
+		this(words, pos, dependency, dependencyWords, dependencyIndices, null);
 	}
 	
 	/**
@@ -35,33 +42,8 @@ public class DependencySample {
 	 * @param dependencyWords 依存关系对应的词
 	 * @param dependencyIndices 依存关系对应的词的下标
 	 */
-	public DependencySample(String[] words,String[] pos,String[] dependency,String[] dependencyWords,String[] dependencyIndices){
-		this(words,pos,dependency,dependencyWords,dependencyIndices,null);
-	}
-	
-	/**
-	 * 构造
-	 * @param words 词语
-	 * @param pos 词性
-	 * @param dependency 依存关系
-	 * @param dependencyWords 依存关系对应的词
-	 * @param dependencyIndices 依存关系对应的词的下标
-	 */
-	public DependencySample(List<String> words,List<String> pos,List<String> dependency,List<String> dependencyWords,List<String> dependencyIndices){
-		this(words,pos,dependency,dependencyWords,dependencyIndices,null);
-	}
-	
-	/**
-	 * 构造
-	 * @param words 词语
-	 * @param pos 词性
-	 * @param dependency 依存关系
-	 * @param dependencyWords 依存关系对应的词
-	 * @param dependencyIndices 依存关系对应的词的下标
-	 * @param additionalContext 额外的信息
-	 */
-	public DependencySample(String[] words,String[] pos,String[] dependency,String[] dependencyWords,String[] dependencyIndices,String[][] additionalContext){
-		this(Arrays.asList(words),Arrays.asList(pos),Arrays.asList(dependency),Arrays.asList(dependencyWords),Arrays.asList(dependencyIndices),additionalContext);
+	public DependencySample(List<String> words, List<String> pos, List<String> dependency, List<String> dependencyWords, List<String> dependencyIndices){
+		this(words, pos, dependency, dependencyWords, dependencyIndices, null);
 	}
 	
 	/**
@@ -73,7 +55,20 @@ public class DependencySample {
 	 * @param dependencyIndices 依存关系对应的词的下标
 	 * @param additionalContext 额外的信息
 	 */
-    public DependencySample(List<String> words,List<String> pos,List<String> dependency,List<String> dependencyWords,List<String> dependencyIndices,String[][] additionalContext){
+	public DependencySample(String[] words, String[] pos, String[] dependency, String[] dependencyWords, String[] dependencyIndices, String[][] additionalContext){
+		this(Arrays.asList(words), Arrays.asList(pos), Arrays.asList(dependency), Arrays.asList(dependencyWords), Arrays.asList(dependencyIndices), additionalContext);
+	}
+	
+	/**
+	 * 构造
+	 * @param words 词语
+	 * @param pos 词性
+	 * @param dependency 依存关系
+	 * @param dependencyWords 依存关系对应的词
+	 * @param dependencyIndices 依存关系对应的词的下标
+	 * @param additionalContext 额外的信息
+	 */
+    public DependencySample(List<String> words, List<String> pos, List<String> dependency, List<String> dependencyWords, List<String> dependencyIndices, String[][] additionalContext){
     	//不能被修改的list
         this.words = Collections.unmodifiableList(words);
         this.pos = Collections.unmodifiableList(pos);
@@ -104,14 +99,54 @@ public class DependencySample {
      */
     public String toCoNLLSample(){
     	String sample = new String();
+    	
+    	if(pos.size() == 0){
+    		for (int i = 0; i < dependency.size(); i++) {
+    			sample += (i + 1) + "\t" + words.get(i + 1) + "\t" + words.get(i + 1) + "\t"
+    					+ "_" + "\t"
+    					+ dependencyIndices.get(i) + "\t"
+    					+ dependency.get(i) + "\t"
+    					+ "_" + "\t" + "_" + "\n";
+    		}
+    	}else{
+    		for (int i = 0; i < dependency.size(); i++) {
+    			sample += (i + 1) + "\t" + words.get(i + 1) + "\t" + words.get(i + 1) + "\t"
+    					+ pos.get(i + 1) + "\t" + pos.get(i + 1) + "\t"
+    					+ "_" + "\t"
+    					+ dependencyIndices.get(i) + "\t"
+    					+ dependency.get(i) + "\t"
+    					+ "_" + "\t" + "_" + "\n";
+    		}
+    	}
+    	
+    	
+    	return sample;
+    }
+    
+    /**
+     * 输出Stanford依存语料样式
+     * @return
+     */
+    public String toStanfordSample(){
+    	String sample = new String();
     	for (int i = 0; i < dependency.size(); i++) {
-			sample += (i+1)+"\t"+words.get(i+1)+"\t"+words.get(i+1)+"\t"
-					+pos.get(i+1)+"\t"+pos.get(i+1)+"\t"
-					+"_"+"\t"
-					+dependencyIndices.get(i)+"\t"
-					+dependency.get(i)+"\t"
-					+"_"+"\t"+"_"+"\n";
-		}
+    		if(dependencyIndices.get(i).equals("0")){
+    			sample += dependency.get(i) + 
+        				"(" + dependencyWords.get(i) + "-" + dependencyIndices.get(i) +
+        				"," + 
+        				 words.get(i + 1) + "-" + (i + 1) + 
+        				")" + "\n";
+    		}
+    	}
+    	for (int i = 0; i < dependency.size(); i++) {
+    		if(!dependencyIndices.get(i).equals("0")){
+    			sample += dependency.get(i) + 
+        				"(" + dependencyWords.get(i) + "-" + dependencyIndices.get(i) +
+        				"," + 
+        				 words.get(i + 1) + "-" + (i + 1) + 
+        				")" + "\n";
+    		}
+    	}
     	return sample;
     }
     

--- a/src/main/java/com/lc/nlp4han/dependency/DependencySampleParserStanford.java
+++ b/src/main/java/com/lc/nlp4han/dependency/DependencySampleParserStanford.java
@@ -1,0 +1,54 @@
+package com.lc.nlp4han.dependency;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 解析Stanford样式的依存分析语料
+ * 
+ * @author 王馨苇
+ *
+ */
+public class DependencySampleParserStanford implements DependencySampleParser{
+
+	@Override
+	public DependencySample parse(String sentence) {
+		String wordLine[] = sentence.split("\\n");
+		//词
+		List<String> word = new ArrayList<String>();
+		//依赖关系
+		List<String> dependency = new ArrayList<String>();
+		//依赖词语的下标
+		List<String> dependencyIndices = new ArrayList<String>();
+		//依赖的词语
+		List<String> dependencyWords = new ArrayList<String>();
+		
+		word.add("核心");
+		for (int i = 0; i < wordLine.length; i++) {
+			word.add("");
+			dependency.add("");
+			dependencyIndices.add("");
+			dependencyWords.add("");
+		}
+		
+		for (int i = 0; i < wordLine.length; i++) {
+			String[] temp = wordLine[i].split("\\(");
+				
+			String[] str = temp[1].split("\\,");
+			
+			String wordindex = str[1].split("-")[1].substring(0, str[1].split("-")[1].length() - 1);
+			int index = Integer.parseInt(wordindex);
+			System.out.println(str[1].split("-")[0]);
+			word.set(index, str[1].split("-")[0]);
+			dependency.set(index - 1, temp[0]);
+			dependencyWords.set(index - 1, str[0].split("-")[0]);
+			dependencyIndices.set(index - 1, str[0].split("-")[1]);
+		}
+
+		return new DependencySample(word.toArray(new String[word.size()]), 
+				new String[]{}, 
+				dependency.toArray(new String[dependency.size()]), 
+				dependencyWords.toArray(new String[dependencyWords.size()]), 
+				dependencyIndices.toArray(new String[dependencyIndices.size()]));
+	}
+}

--- a/src/test/java/com/lc/nlp4han/dependency/DependencySampleParserCoNLLTest.java
+++ b/src/test/java/com/lc/nlp4han/dependency/DependencySampleParserCoNLLTest.java
@@ -1,0 +1,58 @@
+package com.lc.nlp4han.dependency;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * 解析CoNLL语料的单元测试
+ * 测试解析后样本输出为CoNLL格式、输出为Stanford样式
+ * 
+ * @author 王馨苇
+ *
+ */
+public class DependencySampleParserCoNLLTest {
+
+	private String corpus;
+	private DependencySampleParser parser;
+	private DependencySample sample;
+	
+	@Before
+	public void setUp(){
+		corpus = "1	坚决	坚决	a	a	_	2	方式	_	_" + "\n" +
+	             "2	惩治	惩治	v	v	_	0	核心成分	_	_" + "\n" +
+	             "3	贪污	贪污	v	v	_	7	限定	_	_" + "\n" +
+	             "4	贿赂	贿赂	n	n	_	3	连接依存	_	_" + "\n" +
+	             "5	等	等	u	u	_	3	连接依存	_	_" + "\n" +
+	             "6	经济	经济	n	n	_	7	限定	_	_" + "\n" +
+	             "7	犯罪	犯罪	v	v	_	2	受事	_	_" + "\n" ;
+		
+		parser = new DependencySampleParserCoNLL();
+		sample = parser.parse(corpus);
+	}
+	
+	/**
+	 * 测试输出为CoNLL格式
+	 */
+	@Test
+	public void testCoNLL(){
+		assertEquals(corpus, sample.toCoNLLSample());
+	}
+	
+	/**
+	 * 输出为Stanford样式
+	 */
+	@Test
+	public void testStanford(){
+		String result = 
+				"核心成分(核心-0,惩治-2)" + "\n" +
+				"方式(惩治-2,坚决-1)" + "\n" +
+				"限定(犯罪-7,贪污-3)" + "\n" +
+				"连接依存(贪污-3,贿赂-4)" + "\n" +
+				"连接依存(贪污-3,等-5)" + "\n" +
+				"限定(犯罪-7,经济-6)" + "\n" +
+				"受事(惩治-2,犯罪-7)" + "\n" ;
+		assertEquals(result, sample.toStanfordSample());
+	}
+}

--- a/src/test/java/com/lc/nlp4han/dependency/DependencySampleParserStanfordTest.java
+++ b/src/test/java/com/lc/nlp4han/dependency/DependencySampleParserStanfordTest.java
@@ -1,0 +1,59 @@
+package com.lc.nlp4han.dependency;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * 解析Stanford语料的单元测试
+ * 测试解析后样本输出为CoNLL格式、输出为Stanford样式
+ * 
+ * @author 王馨苇
+ *
+ */
+public class DependencySampleParserStanfordTest {
+
+	private String corpus;
+	private DependencySampleParser parser;
+	private DependencySample sample;
+	
+	@Before
+	public void setUp(){
+		corpus =
+				"核心成分(核心-0,惩治-2)" + "\n" +
+				"方式(惩治-2,坚决-1)" + "\n" +
+				"限定(犯罪-7,贪污-3)" + "\n" +
+				"连接依存(贪污-3,贿赂-4)" + "\n" +
+				"连接依存(贪污-3,等-5)" + "\n" +
+				"限定(犯罪-7,经济-6)" + "\n" +
+				"受事(惩治-2,犯罪-7)" + "\n" ;
+
+		parser = new DependencySampleParserStanford();
+		sample = parser.parse(corpus);
+	}
+	
+	/**
+	 * 测试输出为CoNLL格式
+	 */
+	@Test
+	public void testStanford(){
+		assertEquals(corpus, sample.toStanfordSample());
+	}
+	
+	/**
+	 * 输出为Stanford样式
+	 */
+	@Test
+	public void testCoNLL(){
+		String result = 
+				"1	坚决	坚决	_	2	方式	_	_" + "\n" +
+			    "2	惩治	惩治	_	0	核心成分	_	_" + "\n" +
+			    "3	贪污	贪污	_	7	限定	_	_" + "\n" +
+			    "4	贿赂	贿赂	_	3	连接依存	_	_" + "\n" +
+			    "5	等	等	_	3	连接依存	_	_" + "\n" +
+			    "6	经济	经济	_	7	限定	_	_" + "\n" +
+			    "7	犯罪	犯罪	_	2	受事	_	_" + "\n" ;
+		assertEquals(result, sample.toCoNLLSample());
+	}
+}


### PR DESCRIPTION
1、在DependencySample类中增加toStanfordSample方法
2、改动DependencySample类toCoNLLSample方法：判断是否有词性，没有词性，十列输出缩减为八列，否则按照十列输出
3、增加DependencySampleParserStanford样本解析类，解析的结果没有，词性设置为new String[]{}，而不是NULL。
     原因：保证代码通用性，后期特征生成，最大生成树用到了词性，设置为NULL会报错。这样在用Stanford语料的时候，只要将特征配置文件中词性配置为false就行了。