### PR TITLE
1.CFG添加hashCode和equals方法，以及删除无用的方法，以及导致的GrammarTest的修改

### DIFF
--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/pcfg/CFG.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/pcfg/CFG.java
@@ -85,18 +85,6 @@ public class CFG {
 	public void setTerminalSet(Set<String> terminalSet) {
 		this.terminalSet = terminalSet;
 	}
-	 public HashMap<String, HashSet<RewriteRule>> getRuleMapStartWithlhs() {
-			return ruleMapStartWithlhs;
-		}
-		public void setRuleMapStartWithlhs(HashMap<String, HashSet<RewriteRule>> ruleMapStartWithlhs) {
-			this.ruleMapStartWithlhs = ruleMapStartWithlhs;
-		}
-		public HashMap<ArrayList<String>,HashSet<RewriteRule>> getRuleMapStartWithrhs() {
-			return ruleMapStartWithrhs;
-		}
-		public void setRuleMapStartWithrhs(HashMap<ArrayList<String>,HashSet<RewriteRule>> ruleMapStartWithrhs) {
-			this.ruleMapStartWithrhs = ruleMapStartWithrhs;
-		}
 		/*
 		 * 添加单个规则
 		 */
@@ -142,12 +130,62 @@ public class CFG {
 	/*
 	 * 根据规则右部得到所有对应规则
 	 */
-	public Set<RewriteRule> getRuleByrhs(String ...args){
-		ArrayList<String> rhsVector=new ArrayList<String>();
-		for(String string : args) {
-			rhsVector.add(string);
-		}
-		return ruleMapStartWithrhs.get(rhsVector);
+	public Set<RewriteRule> getRuleByrhs(ArrayList<String> rhsList){
+		return ruleMapStartWithrhs.get(rhsList);
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((nonTerminalSet == null) ? 0 : nonTerminalSet.hashCode());
+		result = prime * result + ((ruleMapStartWithlhs == null) ? 0 : ruleMapStartWithlhs.hashCode());
+		result = prime * result + ((ruleMapStartWithrhs == null) ? 0 : ruleMapStartWithrhs.hashCode());
+		result = prime * result + ((ruleSet == null) ? 0 : ruleSet.hashCode());
+		result = prime * result + ((startSymbol == null) ? 0 : startSymbol.hashCode());
+		result = prime * result + ((terminalSet == null) ? 0 : terminalSet.hashCode());
+		return result;
+	}
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CFG other = (CFG) obj;
+		if (nonTerminalSet == null) {
+			if (other.nonTerminalSet != null)
+				return false;
+		} else if (!nonTerminalSet.equals(other.nonTerminalSet))
+			return false;
+		if (ruleMapStartWithlhs == null) {
+			if (other.ruleMapStartWithlhs != null)
+				return false;
+		} else if (!ruleMapStartWithlhs.equals(other.ruleMapStartWithlhs))
+			return false;
+		if (ruleMapStartWithrhs == null) {
+			if (other.ruleMapStartWithrhs != null)
+				return false;
+		} else if (!ruleMapStartWithrhs.equals(other.ruleMapStartWithrhs))
+			return false;
+		if (ruleSet == null) {
+			if (other.ruleSet != null)
+				return false;
+		} else if (!ruleSet.equals(other.ruleSet))
+			return false;
+		if (startSymbol == null) {
+			if (other.startSymbol != null)
+				return false;
+		} else if (!startSymbol.equals(other.startSymbol))
+			return false;
+		if (terminalSet == null) {
+			if (other.terminalSet != null)
+				return false;
+		} else if (!terminalSet.equals(other.terminalSet))
+			return false;
+		return true;
 	}
 	@Override
 	public String toString()  {

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/pcfg/CFGConvertToCNFTool.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/pcfg/CFGConvertToCNFTool.java
@@ -1,0 +1,42 @@
+package com.lc.nlp4han.constituent.pcfg;
+
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+public class CFGConvertToCNFTool
+{
+
+	public static void main(String[] args) throws IOException
+	{
+		if(args.length<1) {
+			return;
+		}
+		String CFGpath=null;
+		String CNFpath=null;
+		String encoding=null;
+		for(int i=0;i<args.length;i++) {
+			if(args[i].equals("-CFGpath")) {
+				CFGpath=args[i+1];
+				i++;
+			}
+			if(args[i].equals("-CNFpath")) {
+				CNFpath=args[i+1];
+				i++;
+			}
+			if(args[i].equals("-encoding")) {
+				encoding=args[i+1];
+				i++;
+			}
+		}
+		readCFGAndConvertToCNF(CFGpath,CNFpath,encoding);
+
+	}
+    private static void readCFGAndConvertToCNF(String CFGpath,String CNFpath,String encoding) throws IOException {
+    	BufferedWriter bw=new BufferedWriter(new OutputStreamWriter(new FileOutputStream(CNFpath),encoding));
+    	CFG cfg=new GetCFGFromFile().getCFGFromFile(CFGpath, encoding);
+    	bw.append(new ConvertCFGToCNF().convertToCNF(cfg).toString());
+ 	    bw.close();
+    }
+}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/pcfg/ConvertCFGToCNF.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/pcfg/ConvertCFGToCNF.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 public class ConvertCFGToCNF {
 	 private CFG cnf;
-	 
+	 private Set<RewriteRule> set=new HashSet<RewriteRule>();
      public CFG convertToCNF(CFG cfg) {
     	 cnf=new CFG();
 		 cnf.setNonTerminalSet(cfg.getNonTerminalSet());
@@ -74,7 +74,7 @@ public class ConvertCFGToCNF {
     	 HashSet<RewriteRule> deleteRuleSet=new HashSet<RewriteRule>();
     	 /*
     	  * 因为此时，原始数据cfg中右侧字符串的个数为1的规则并未处理
-    	  * 而在前期操作中添加的右侧只有一个字符串的规则不需要，所以可以调用cfg来遍历
+    	  * 而在前期操作中添加的右侧只有一个字符串的规则不需要转换，所以可以调用cfg来遍历
     	  */
     	 for(RewriteRule rule :cfg.getRuleSet()) {
     		 if(rule.getRhs().size()==1) {
@@ -111,18 +111,25 @@ public class ConvertCFGToCNF {
       * 遍历消除Unit Production
       */
      private void removeUnitProduction(RewriteRule rule) {
-    	 Set<RewriteRule> ruleSet=cnf.getRuleBylhs(rule.getRhs().get(0));
+    	 if(set.contains(rule)) {
+    		 return;
+    	 }
+    	 set.add(rule);
+    	 Set<RewriteRule> ruleSet=new HashSet<RewriteRule>();
+    	 //需要将其重新装入一个HashSet中，否则在遍历时set的迭代器会报错
+    	 for(RewriteRule rule4: cnf.getRuleBylhs(rule.getRhs().get(0))){
+    		 ruleSet.add(rule4);
+    	 }
     	 for(RewriteRule rule1: ruleSet) {
     		 RewriteRule rule2=new RewriteRule(rule.getLhs(),rule1.getRhs());
     		 if(rule1.getRhs().size()==1&&rule1.getLhs().equals(rule1.getRhs().get(0))) {
     			 continue;//左右侧相同的跳过不添加
     		 }
     		if(rule1.getRhs().size()==1&&cnf.getNonTerminalSet().contains(rule1.getRhs().get(0))) {
-    			 removeUnitProduction(rule2); 
+    			removeUnitProduction(rule2); 
     		} else {
-        		 cnf.add(rule2); 
+    			cnf.add(rule2); 
     		 }
-
     	 }
      }
      /*
@@ -156,8 +163,8 @@ public class ConvertCFGToCNF {
      private void deleteRules(HashSet<RewriteRule> ruleSet) {
     	 for(RewriteRule rule: ruleSet) {
     		 cnf.getRuleSet().remove(rule);
-    		 cnf.getRuleMapStartWithlhs().get(rule.getLhs()).remove(rule);
-    		 cnf.getRuleMapStartWithrhs().get(rule.getRhs()).remove(rule);
+    		 cnf.getRuleBylhs(rule.getLhs()).remove(rule);
+    		 cnf.getRuleByrhs(rule.getRhs()).remove(rule);
     	 }
     	 
      }

--- a/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/pcfg/GrammarTest.java
+++ b/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/pcfg/GrammarTest.java
@@ -63,13 +63,15 @@ public class GrammarTest {
     	rules.add(new RewriteRule("NP","NN","NN","NN","NN"));
     	
     	rules3.add(new RewriteRule("Aux-VP","会","VP"));
-    	
+    	ArrayList<String> strList=new ArrayList<String>();
+    	strList.add("会");
+    	strList.add("VP");
     	//判别是否为CNF的测试
     	Assert.assertFalse(cfg.IsCNF());
     	//测试由规则左侧得到的集合是否准确完整
     	Assert.assertTrue(cfg.getRuleBylhs("NP").containsAll(rules)&&rules.containsAll(cfg.getRuleBylhs("NP")));
     	//规则右侧集的测试
-    	Assert.assertEquals(cfg.getRuleByrhs("会","VP"),rules3);
+    	Assert.assertEquals(cfg.getRuleByrhs(strList),rules3);
     	//起始符测试
     	Assert.assertEquals(startSymbol,cfg.getStartSymbol());
     	//非终结符集的测试


### PR DESCRIPTION
2.CFGConvertToCFG中消除单位产品方法的过程修正，提高效率
3.添加CFGConvertToCNFTool应用程序，从文件中提取CFG转换为CNF然后存入指定文件中