### PR TITLE
1.修改了UnlexEvaTool名称；2.增加了父节点标注的交叉验证；3.修改了单元测试代码；4.现在TreeBank通过不断加入树构建；

### DIFF
--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Annotation.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Annotation.java
@@ -2,6 +2,7 @@ package com.lc.nlp4han.constituent.unlex;
 
 /**
  * 树中的节点
+ * 
  * @author 王宁
  */
 public class Annotation
@@ -12,6 +13,8 @@ public class Annotation
 	private short spanFrom, spanTo;// 记一个句子W中的词语下标从0到length-1。非终结符号A产生句子W_i->W_j,则A_spanFrom = i, A_spanTo = j+1;
 	private Double[] innerScores;// 内向概率
 	private Double[] outerScores;// 外向概率
+	private int innerScale = 0;// 内向概率缩放比例的log值，真实inScore[i] = innerScores[i]*(exp(100)^innerScale)。
+	private int outerScale = 0;// 外向概率缩放比例的log值
 
 	public Annotation(short symbol, short numSubSymbol)
 	{
@@ -94,4 +97,23 @@ public class Annotation
 		this.outerScores = outerScores;
 	}
 
+	public int getInnerScale()
+	{
+		return innerScale;
+	}
+
+	public void setInnerScale(int innerScale)
+	{
+		this.innerScale = innerScale;
+	}
+
+	public int getOuterScale()
+	{
+		return outerScale;
+	}
+
+	public void setOuterScale(int outerScale)
+	{
+		this.outerScale = outerScale;
+	}
 }

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/AnnotationTreeNode.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/AnnotationTreeNode.java
@@ -85,15 +85,17 @@ public class AnnotationTreeNode extends TreeNode
 			return false;
 	}
 
-	public AnnotationTreeNode forgetIOScore()
+	public AnnotationTreeNode forgetIOScoreAndScale()
 	{
 		if (this.isLeaf() || this == null)
 			return this;
 		label.setInnerScores(null);
 		label.setOuterScores(null);
+		label.setInnerScale(0);
+		label.setOuterScale(0);
 		for (AnnotationTreeNode child : this.getChildren())
 		{
-			child.forgetIOScore();
+			child.forgetIOScoreAndScale();
 		}
 		return this;
 	}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/BinaryRule.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/BinaryRule.java
@@ -16,9 +16,6 @@ public class BinaryRule extends Rule
 	private short rightChild;
 	LinkedList<LinkedList<LinkedList<Double>>> scores = new LinkedList<LinkedList<LinkedList<Double>>>();// 保存规则例如A_i ->
 																											// B_j
-																											// C_k的概率
-	double[][][] countExpectation = null;
-
 	public BinaryRule(short parent, short lChild, short rChild)
 	{
 		super.parent = parent;
@@ -263,16 +260,6 @@ public class BinaryRule extends Rule
 	public void setScores(LinkedList<LinkedList<LinkedList<Double>>> scores)
 	{
 		this.scores = scores;
-	}
-
-	public double[][][] getCountExpectation()
-	{
-		return countExpectation;
-	}
-
-	public void setCountExpectation(double[][][] countExpectation)
-	{
-		this.countExpectation = countExpectation;
 	}
 
 	@Override

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Grammar.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Grammar.java
@@ -31,8 +31,6 @@ public class Grammar
 	protected HashMap<Short, HashMap<UnaryRule, UnaryRule>> uRuleBySameHead;
 
 	protected NonterminalTable nonterminalTable;
-	// 使用规则数量的期望的比作为新的规则概率
-	protected HashMap<Short, Double[]> sameParentRulesCount = new HashMap<>();// <parent,[ParentSubIndex,denominator]>
 	public double mergeWeight[][];
 	public static Random random = new Random(0);
 
@@ -53,21 +51,21 @@ public class Grammar
 		grammarExam();
 	}
 
-	public void forgetRuleCountExpectation()
-	{
-		for (UnaryRule uRule : uRules)
-		{
-			uRule.setCountExpectation(null);
-		}
-		for (BinaryRule bRule : bRules)
-		{
-			bRule.setCountExpectation(null);
-		}
-		for (PreterminalRule preRule : lexicon.getPreRules())
-		{
-			preRule.setCountExpectation(null);
-		}
-	}
+//	public void forgetRuleCountExpectation()
+//	{
+//		for (UnaryRule uRule : uRules)
+//		{
+//			uRule.setCountExpectation(null);
+//		}
+//		for (BinaryRule bRule : bRules)
+//		{
+//			bRule.setCountExpectation(null);
+//		}
+//		for (PreterminalRule preRule : lexicon.getPreRules())
+//		{
+//			preRule.setCountExpectation(null);
+//		}
+//	}
 
 	/**
 	 * 返回CFG，其中规则包含一元规则、二元规则

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarExtractorTool.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarExtractorTool.java
@@ -13,18 +13,14 @@ public class GrammarExtractorTool
 	public static Grammar getGrammar(int SMCycle, double mergeRate, int EMIterations, boolean addParentLabel,
 			int rareWordThreshold, String treeBankPath, String encoding) throws IOException
 	{
-		GrammarExtractor gExtractor;
+		GrammarExtractor gExtractor = new GrammarExtractor(treeBankPath, addParentLabel, encoding);
 		if (SMCycle <= 0)
 		{
-			gExtractor = new GrammarExtractor(addParentLabel, rareWordThreshold, treeBankPath, encoding);
-			return gExtractor.getGrammar();
+			return gExtractor.getGrammar(rareWordThreshold);
 		}
-
 		else
 		{
-			gExtractor = new GrammarExtractor(SMCycle, mergeRate, EMIterations, addParentLabel, rareWordThreshold,
-					treeBankPath, encoding);
-			return gExtractor.getGrammar(SMCycle, mergeRate, EMIterations);
+			return gExtractor.getGrammar(SMCycle, mergeRate, EMIterations, rareWordThreshold);
 		}
 	}
 
@@ -34,6 +30,8 @@ public class GrammarExtractorTool
 		String outputFilePath = null;
 		String encoding = "utf-8";
 		int iterations = 50;// em算法迭代次数
+		int SMCycle = 1;
+		boolean addParentLabel = false;
 		for (int i = 0; i < args.length; i++)
 		{
 			if (args[i].equals("-train"))
@@ -46,9 +44,19 @@ public class GrammarExtractorTool
 				outputFilePath = args[i + 1];
 				i++;
 			}
+			if (args[i].equals("-sm"))
+			{
+				SMCycle = Integer.parseInt(args[i + 1]);
+				i++;
+			}
 			if (args[i].equals("-encoding"))
 			{
 				encoding = args[i + 1];
+				i++;
+			}
+			if (args[i].equals("-plabel"))
+			{
+				addParentLabel = Boolean.parseBoolean(args[i + 1]);
 				i++;
 			}
 			if (args[i].equals("-em"))
@@ -63,44 +71,17 @@ public class GrammarExtractorTool
 			usage();
 			System.exit(0);
 		}
-
 		try
 		{
 			long start = System.currentTimeMillis();
 			System.out.println("开始提取初始文法");
-			Grammar g = GrammarExtractorTool.getGrammar(1, 0.5, iterations, false, Lexicon.DEFAULT_RAREWORD_THRESHOLD,
-					trainFilePath, encoding);
+			Grammar g = GrammarExtractorTool.getGrammar(SMCycle, 0.5, iterations, addParentLabel,
+					Lexicon.DEFAULT_RAREWORD_THRESHOLD, trainFilePath, encoding);
 			GrammarWriter.writerToFile(g, outputFilePath);
 			System.out.println("提取初始文法完毕");
 			long end = System.currentTimeMillis();
 			long time = end - start;
 			System.out.println("提取语法消耗时间：" + time);
-
-			// long start1 = System.currentTimeMillis();
-			// PCFG pcfg = g.getPCFG();
-			// ConstituentParserCKYP2NF parser = new ConstituentParserCKYP2NF(pcfg);
-			// long end1 = System.currentTimeMillis();
-			// System.out.println("语法转化消耗时间：" + (end1 - start1));
-			// String sentence = "(ROOT(IP(NP(NP(NR 上海)(NR 浦东))(NP(NN 开发)(CC 与)(NN 法制)(NN
-			// 建设)))(VP(VV 同步))))";
-			// String sentence = "(ROOT(FRAG(P 据)(NR 新华社)(NR 伦敦)(NT ２月)(NT １３日)(NN 电)))";
-			// TreeNode root = BracketExpUtil.generateTree(sentence);
-			// TreeUtil.addParentLabel(root);
-			// ArrayList<String> allWords = new ArrayList<>();
-			// ArrayList<String> allPoses = new ArrayList<>();
-			// TreeNodeUtil.getWordsAndPOSFromTree(allWords, allPoses, root);
-			// // String[] words = { "上海", "浦东", "开发", "与", "法制", "建设", "同步" };
-			// // // String[] poses = { "NR", "NR", "NN", "CC", "NN", "NN", "VV" };
-			// // String[] poses = { "NR^NP", "NR^NP", "NN^NP", "CC^NP", "NN^NP", "NN^NP",
-			// // "VV^VP" };
-			// String words[] = allWords.toArray(new String[allWords.size()]);
-			// String poses[] = allPoses.toArray(new String[allPoses.size()]);
-			// long strat2 = System.currentTimeMillis();
-			// ConstituentTree ctree = parser.parse(words, poses);
-			// TreeNode tree = TreeUtil.removeParentLabel(ctree.getRoot());
-			// long end2 = System.currentTimeMillis();
-			// System.out.println("解析时间：" + (end2 - strat2));
-			// System.out.println(TreeNode.printTree(tree, 0));
 		}
 		catch (IOException e)
 		{
@@ -111,6 +92,6 @@ public class GrammarExtractorTool
 	private static void usage()
 	{
 		System.out.println(GrammarExtractorTool.class.getName() + "\n"
-				+ " -train <trainFile> -out <outFile> [-encoing <encoding>] [-em <emIterations>]");
+				+ " -train <trainFile> -out <outFile> [-sm <SMCycle>] [-encoing <encoding>] [-em <emIterations>] [-plabel <addParentLabel>]");
 	}
 }

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarExtractorTool.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarExtractorTool.java
@@ -30,7 +30,7 @@ public class GrammarExtractorTool
 		String outputFilePath = null;
 		String encoding = "utf-8";
 		int iterations = 50;// em算法迭代次数
-		int SMCycle = 1;
+		int SMCycle = 3;
 		boolean addParentLabel = false;
 		for (int i = 0; i < args.length; i++)
 		{

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarMerger.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarMerger.java
@@ -54,7 +54,7 @@ public class GrammarMerger
 		if (tree.isLeaf())
 			return;
 		tree.getLabel().setNumSubSymbol(g.nonterminalTable.getNumSubsymbolArr().get(tree.getLabel().getSymbol()));
-		tree.forgetIOScore();
+		tree.forgetIOScoreAndScale();
 		tree.getLabel().setInnerScores(null);
 		tree.getLabel().setOuterScores(null);
 		for (AnnotationTreeNode child : tree.getChildren())
@@ -63,6 +63,7 @@ public class GrammarMerger
 		}
 	}
 
+	// TODO:处理期望值为0的
 	public static double[][] computerMergerWeight(Grammar g)
 	{
 		double[][] mergerWeight = new double[g.nonterminalTable.getNumSymbol()][];
@@ -88,25 +89,25 @@ public class GrammarMerger
 	{
 		ArrayList<Short>[] symbolToMerge = new ArrayList[g.nonterminalTable.getNumSymbol()];
 		PriorityQueue<SentenceLikehood> senScoreGradient = new PriorityQueue<>();
-		// assume a subState without split,root 没有分裂
+		// 假设一个符号没有分裂,已知root 没有分裂
 		for (short i = 1; i < g.nonterminalTable.getNumSymbol(); i++)
 		{
 			for (short j = 0; j < g.nonterminalTable.getNumSubsymbolArr().get(i); j++)
 			{
-				double tallyGradient = 1;
-				System.out.println(
-						"若合并非终结符号" + g.nonterminalTable.stringValue(i) + "的第" + j + "," + (j + 1) + "个子符号后树库似然比：");
+				double tallyLogGradient = 0;
 				for (AnnotationTreeNode tree : treeBank.getTreeBank())
 				{
-					double sentenceScoreGradient = getMergeSymbolHelper(g, tree, i, j, mergeWeight);
-					tallyGradient *= sentenceScoreGradient;
+					double logSenScoreGradient = getMergeSymbolHelper(g, tree, i, j, mergeWeight);
+					tallyLogGradient += logSenScoreGradient;
 				}
-				System.out.println(tallyGradient);
-				senScoreGradient.add(new SentenceLikehood(i, j, tallyGradient));
+				System.out.println("若合并非终结符号" + g.nonterminalTable.stringValue(i) + "的第" + j + "," + (j + 1)
+						+ "个子符号后树库似然比：" + tallyLogGradient);
+				senScoreGradient.add(new SentenceLikehood(i, j, tallyLogGradient));
 				j++;
 			}
 		}
 		int mergeCount = (int) (senScoreGradient.size() * mergeRate);
+		double litterBigger = 0.0;
 		System.out.println("预计合并" + mergeCount + "对子符号。");
 		for (int i = 0; i < mergeCount; i++)
 		{
@@ -115,20 +116,24 @@ public class GrammarMerger
 			{
 				symbolToMerge[s.symbol] = new ArrayList<Short>();
 			}
-			if (s.sentenceScoreGradient < 1)
+			if (s.logAllSenScoreGradient < 0)
 			{
 				System.out.println("实际合并" + i + "对子符号。");
+				System.out.println("合并第" + i + "对子符号后，树库与合并前的似然值之比为：" + litterBigger);
 				break;
 			}
-			symbolToMerge[s.symbol].add(s.subSymbolIndex);
-
 			if (i == mergeCount - 1)
-				System.out.println("合并第" + (i + 1) + "对子符号后，树库与合并前的似然值之比为：" + s.sentenceScoreGradient);
+			{
+				System.out.println("实际合并" + (i + 1) + "对子符号******");
+				System.out.println("合并第" + (i + 1) + "对子符号后，树库与合并前的似然值之比为：" + s.logAllSenScoreGradient);
+			}
+			symbolToMerge[s.symbol].add(s.subSymbolIndex);
+			litterBigger = s.logAllSenScoreGradient;
 		}
 
 		Short[][] mergeSymbols = new Short[symbolToMerge.length][];
 		Short[] subSymbolToMerge;
-		//// assume a subState without split,root 没有分裂
+		// assume a subState without split,root 没有分裂
 		for (int i = 1; i < symbolToMerge.length; i++)
 		{
 			if (symbolToMerge[i] != null)
@@ -159,18 +164,18 @@ public class GrammarMerger
 	public static double getMergeSymbolHelper(Grammar g, AnnotationTreeNode tree, short symbol, short subSymbolIndex,
 			double[][] mergeWeight)
 	{
-		double senScoreGradient = 1.0;
+		double logSenScoreGradient = 0;
 		for (AnnotationTreeNode child : tree.getChildren())
 		{
 			if (!child.isLeaf())
-				senScoreGradient *= getMergeSymbolHelper(g, child, symbol, subSymbolIndex, mergeWeight);
+				logSenScoreGradient += getMergeSymbolHelper(g, child, symbol, subSymbolIndex, mergeWeight);
 		}
 		if (tree.getLabel().getSymbol() == symbol && symbol != 0)
 		{
-			senScoreGradient *= calSenSocreAssumeMergeState_i(tree, subSymbolIndex, mergeWeight)
-					/ TreeBank.calculateSentenceSocre(tree);
+			logSenScoreGradient += calLogSenSocreAssumeMergeState_i(tree, subSymbolIndex, mergeWeight)
+					- TreeBank.calLogSentenceSocre(tree);
 		}
-		return senScoreGradient;
+		return logSenScoreGradient;
 	}
 
 	/**
@@ -178,7 +183,7 @@ public class GrammarMerger
 	 * @param 树中要合并的节点的subStateIndex
 	 * @return 树的似然值
 	 */
-	public static double calSenSocreAssumeMergeState_i(AnnotationTreeNode node, int subStateIndex,
+	public static double calLogSenSocreAssumeMergeState_i(AnnotationTreeNode node, int subStateIndex,
 			double[][] mergeWeight)
 	{
 
@@ -202,6 +207,10 @@ public class GrammarMerger
 			{
 				double iWeight = mergeWeight[node.getLabel().getSymbol()][i];
 				double brotherWeight = mergeWeight[node.getLabel().getSymbol()][i + 1];
+				if (iWeight == Double.NaN || brotherWeight == Double.NaN)
+				{
+					System.err.println(" count Of SubSymbol_Si and SubSymbol_Si+1 underFlow.");
+				}
 				sentenceScore += (iWeight * innerScore[i] + brotherWeight * innerScore[i + 1])
 						* (outerScores[i] + outerScores[i + 1]);
 				i++;
@@ -211,18 +220,20 @@ public class GrammarMerger
 				sentenceScore += innerScore[i] * outerScores[i];
 			}
 		}
-		return sentenceScore;
+		double logSenScore = Math.log(sentenceScore)
+				+ 100 * (node.getLabel().getInnerScale() + node.getLabel().getOuterScale());
+		return logSenScore;
 	}
 
 	static class SentenceLikehood implements Comparable<SentenceLikehood>
 	{
 		short symbol;
 		short subSymbolIndex;
-		double sentenceScoreGradient;
+		double logAllSenScoreGradient;
 
-		SentenceLikehood(short symbol, short subSymbolIndex, double sentenceScoreGradient)
+		SentenceLikehood(short symbol, short subSymbolIndex, double logAllSenScoreGradient)
 		{
-			this.sentenceScoreGradient = sentenceScoreGradient;
+			this.logAllSenScoreGradient = logAllSenScoreGradient;
 			this.symbol = symbol;
 			this.subSymbolIndex = subSymbolIndex;
 		}
@@ -230,9 +241,9 @@ public class GrammarMerger
 		@Override
 		public int compareTo(SentenceLikehood o)
 		{
-			if (this.sentenceScoreGradient > o.sentenceScoreGradient)
+			if (this.logAllSenScoreGradient > o.logAllSenScoreGradient)
 				return -1;
-			else if (this.sentenceScoreGradient < o.sentenceScoreGradient)
+			else if (this.logAllSenScoreGradient < o.logAllSenScoreGradient)
 				return 1;
 			else
 				return 0;

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarTrainer.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/GrammarTrainer.java
@@ -1,7 +1,5 @@
 package com.lc.nlp4han.constituent.unlex;
 
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Map;
 
 /**
@@ -12,19 +10,18 @@ import java.util.Map;
 public class GrammarTrainer
 {
 	public static int EMIterations = 50;
+	public static RuleCounter ruleCounter;
 
 	public static Grammar train(Grammar g, TreeBank treeBank, int SMCycle, double mergeRate, int EMIterations)
 	{
 		System.out.println("SMCycle:" + SMCycle);
 		for (int i = 0; i < SMCycle; i++)
 		{
-			GrammarSpliter.splitGrammar(g, treeBank);
+			// GrammarSpliter.splitGrammar(g, treeBank);
 			EM(g, treeBank, EMIterations);
 			System.err.println("分裂完成。");
-			GrammarMerger.mergeGrammar(g, treeBank, mergeRate);
-			EM(g, treeBank, EMIterations);
-			g.sameParentRulesCount = new HashMap<>();
-			treeBank.forgetIOScoreAndScale();
+			// GrammarMerger.mergeGrammar(g, treeBank, mergeRate, ruleCounter);
+//			EM(g, treeBank, EMIterations);
 			System.err.println("合并完成。");
 		}
 		return g;
@@ -37,121 +34,137 @@ public class GrammarTrainer
 	{
 		for (int i = 0; i < iterations; i++)
 		{
-			for (AnnotationTreeNode tree : treeBank.getTreeBank())
-			{
-				// System.out.println("计算第" + count + "颗树的内外向概率。");
-				TreeBank.calculateInnerScore(g, tree);
-				TreeBank.calculateOuterScore(g, tree);
-				refreshRuleCountExpectation(g, tree, tree);
-				if (i != iterations - 1)
-				{
-					tree.forgetIOScoreAndScale();
-				}
-			}
-			refreshRuleScore(g);
-			if (i != iterations - 1)
-			{
-				g.sameParentRulesCount = new HashMap<>();
-			}
-			g.forgetRuleCountExpectation();
-			// System.out.println("第" + (i + 1) + "次EM结束");
+			ruleCounter = new RuleCounter();
+			calRuleExpectation(g, treeBank);
+			recalculateRuleScore(g);
 		}
 		System.out.println("EM算法结束。");
 	}
 
-	public static void refreshRuleCountExpectation(Grammar g, AnnotationTreeNode root, AnnotationTreeNode tree)
+	public static void calRuleExpectation(Grammar g, TreeBank treeBank)
 	{
-
-		if (tree.getChildren().size() == 0 || tree == null)
-			return;
-		Rule rule = null;
-		double scalingFactor;
-		if (tree.getChildren().size() == 2)
-		{
-
-			AnnotationTreeNode lC = tree.getChildren().get(0);
-			AnnotationTreeNode rC = tree.getChildren().get(1);
-			rule = new BinaryRule(tree.getLabel().getSymbol(), lC.getLabel().getSymbol(), rC.getLabel().getSymbol());
-			LinkedList<LinkedList<LinkedList<Double>>> scores = g.bRuleBySameHead.get(tree.getLabel().getSymbol())
-					.get(rule).getScores();
-			double[][][] count = g.bRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).getCountExpectation();
-			if (count == null)
-			{
-				count = new double[tree.getLabel().getNumSubSymbol()][lC.getLabel().getNumSubSymbol()][rC.getLabel()
-						.getNumSubSymbol()];
-			}
-			scalingFactor = ScalingTools.calcScaleFactor(tree.getLabel().getOuterScale() + lC.getLabel().getInnerScale()
-					+ rC.getLabel().getInnerScale() - root.getLabel().getInnerScale());
-			for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
-			{
-				for (int j = 0; j < tree.getChildren().get(0).getLabel().getNumSubSymbol(); j++)
-				{
-					for (int k = 0; k < tree.getChildren().get(1).getLabel().getNumSubSymbol(); k++)
-					{
-						count[i][j][k] = count[i][j][k]
-								+ (scores.get(i).get(j).get(k) * lC.getLabel().getInnerScores()[j]
-										/ root.getLabel().getInnerScores()[0] * rC.getLabel().getInnerScores()[k]
-										* scalingFactor * tree.getLabel().getOuterScores()[i]);
-					}
-				}
-			}
-			g.bRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).setCountExpectation(count);
-		}
-		else if (tree.getChildren().size() == 1 && tree.getChildren().get(0).getLabel().getWord() == null)
-		{
-			AnnotationTreeNode child = tree.getChildren().get(0);
-			rule = new UnaryRule(tree.getLabel().getSymbol(), child.getLabel().getSymbol());
-			LinkedList<LinkedList<Double>> scores = g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule)
-					.getScores();
-			double[][] count = g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).getCountExpectation();
-			if (count == null)
-			{
-				count = new double[tree.getLabel().getNumSubSymbol()][tree.getChildren().get(0).getLabel()
-						.getNumSubSymbol()];
-			}
-			scalingFactor = ScalingTools.calcScaleFactor(tree.getLabel().getOuterScale()
-					+ child.getLabel().getInnerScale() - root.getLabel().getInnerScale());
-			for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
-			{
-				for (int j = 0; j < tree.getChildren().get(0).getLabel().getNumSubSymbol(); j++)
-				{
-					count[i][j] = count[i][j] + (scores.get(i).get(j) * child.getLabel().getInnerScores()[j]
-							/ root.getLabel().getInnerScores()[0] * scalingFactor
-							* tree.getLabel().getOuterScores()[i]);
-				}
-			}
-			g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).setCountExpectation(count);
-		}
-		else if (tree.isPreterminal())
-		{
-			rule = new PreterminalRule(tree.getLabel().getSymbol(), tree.getChildren().get(0).getLabel().getWord());
-			LinkedList<Double> scores = g.preRuleBySameHead.get(rule.getParent()).get(rule).getScores();
-			double[] count = g.preRuleBySameHead.get(rule.getParent()).get(rule).getCountExpectation();
-			if (count == null)
-			{
-				count = new double[tree.getLabel().getNumSubSymbol()];
-			}
-			scalingFactor = ScalingTools
-					.calcScaleFactor(tree.getLabel().getOuterScale() - root.getLabel().getInnerScale());
-			for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
-			{
-				// System.out.println(TreeBank.nonterminalTable.stringValue(tree.getLabel().getSymbol())
-				// + "_" + i + " "
-				// + tree.getLabel().getOuterScores()[i]);
-				count[i] = count[i] + (scores.get(i) / root.getLabel().getInnerScores()[0] * scalingFactor
-						* tree.getLabel().getOuterScores()[i]);
-
-			}
-			g.preRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).setCountExpectation(count);
-		}
-		else if (tree.getChildren().size() > 2)
-			throw new Error("error tree:more than 2 children.");
-
-		for (AnnotationTreeNode child : tree.getChildren())
-		{
-			refreshRuleCountExpectation(g, root, child);
-		}
+		ruleCounter.calRuleExpectation(g, treeBank);
 	}
+
+	// public static void refreshRuleCountExpectation(Grammar g, AnnotationTreeNode
+	// root, AnnotationTreeNode tree)
+	// {
+	// if (tree.getChildren().size() == 0 || tree == null)
+	// return;
+	// double scalingFactor;
+	// if (tree.getChildren().size() == 2)
+	// {
+	// AnnotationTreeNode lC = tree.getChildren().get(0);
+	// AnnotationTreeNode rC = tree.getChildren().get(1);
+	// BinaryRule rule = new BinaryRule(tree.getLabel().getSymbol(),
+	// lC.getLabel().getSymbol(),
+	// rC.getLabel().getSymbol());
+	// rule = g.bRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule);
+	// LinkedList<LinkedList<LinkedList<Double>>> scores = rule.getScores();
+	// double[][][] count;
+	// if (!ruleCounter.bRuleCounter.containsKey(rule))
+	// {
+	// count = new
+	// double[tree.getLabel().getNumSubSymbol()][lC.getLabel().getNumSubSymbol()][rC.getLabel()
+	// .getNumSubSymbol()];
+	// ruleCounter.bRuleCounter.put(rule, count);
+	// }
+	// else
+	// {
+	// count = ruleCounter.bRuleCounter.get(rule);
+	// }
+	// scalingFactor = ScalingTools.calcScaleFactor(tree.getLabel().getOuterScale()
+	// + lC.getLabel().getInnerScale()
+	// + rC.getLabel().getInnerScale() - root.getLabel().getInnerScale());
+	// for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
+	// {
+	// for (int j = 0; j < tree.getChildren().get(0).getLabel().getNumSubSymbol();
+	// j++)
+	// {
+	// for (int k = 0; k < tree.getChildren().get(1).getLabel().getNumSubSymbol();
+	// k++)
+	// {
+	// count[i][j][k] = count[i][j][k]
+	// + (scores.get(i).get(j).get(k) * lC.getLabel().getInnerScores()[j]
+	// / root.getLabel().getInnerScores()[0] * rC.getLabel().getInnerScores()[k]
+	// * scalingFactor * tree.getLabel().getOuterScores()[i]);
+	// }
+	// }
+	// }
+	// g.bRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).setCountExpectation(count);
+	// }
+	// else if (tree.getChildren().size() == 1 &&
+	// tree.getChildren().get(0).getLabel().getWord() == null)
+	// {
+	// AnnotationTreeNode child = tree.getChildren().get(0);
+	// UnaryRule rule = new UnaryRule(tree.getLabel().getSymbol(),
+	// child.getLabel().getSymbol());
+	// LinkedList<LinkedList<Double>> scores =
+	// g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule)
+	// .getScores();
+	// double[][] count =
+	// g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).getCountExpectation();
+	// if (!ruleCounter.uRuleCounter.containsKey(rule))
+	// {
+	// count = new
+	// double[tree.getLabel().getNumSubSymbol()][tree.getChildren().get(0).getLabel()
+	// .getNumSubSymbol()];
+	// }
+	// else
+	// {
+	// count = ruleCounter.uRuleCounter.get(rule);
+	// }
+	// scalingFactor = ScalingTools.calcScaleFactor(tree.getLabel().getOuterScale()
+	// + child.getLabel().getInnerScale() - root.getLabel().getInnerScale());
+	// for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
+	// {
+	// for (int j = 0; j < tree.getChildren().get(0).getLabel().getNumSubSymbol();
+	// j++)
+	// {
+	// count[i][j] = count[i][j] + (scores.get(i).get(j) *
+	// child.getLabel().getInnerScores()[j]
+	// / root.getLabel().getInnerScores()[0] * scalingFactor
+	// * tree.getLabel().getOuterScores()[i]);
+	// }
+	// }
+	// g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).setCountExpectation(count);
+	// }
+	// else if (tree.isPreterminal())
+	// {
+	// PreterminalRule rule = new PreterminalRule(tree.getLabel().getSymbol(),
+	// tree.getChildren().get(0).getLabel().getWord());
+	// LinkedList<Double> scores =
+	// g.preRuleBySameHead.get(rule.getParent()).get(rule).getScores();
+	// double[] count =
+	// g.preRuleBySameHead.get(rule.getParent()).get(rule).getCountExpectation();
+	// if (!ruleCounter.preRuleCounter.containsKey(rule))
+	// {
+	// count = new double[tree.getLabel().getNumSubSymbol()];
+	// }
+	// else
+	// {
+	// count = ruleCounter.preRuleCounter.get(rule);
+	// }
+	// scalingFactor = ScalingTools
+	// .calcScaleFactor(tree.getLabel().getOuterScale() -
+	// root.getLabel().getInnerScale());
+	// for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
+	// {
+	// count[i] = count[i] + (scores.get(i) / root.getLabel().getInnerScores()[0] *
+	// scalingFactor
+	// * tree.getLabel().getOuterScores()[i]);
+	//
+	// }
+	// g.preRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule).setCountExpectation(count);
+	// }
+	// else if (tree.getChildren().size() > 2)
+	// throw new Error("error tree:more than 2 children.");
+	//
+	// for (AnnotationTreeNode child : tree.getChildren())
+	// {
+	// refreshRuleCountExpectation(g, root, child);
+	// }
+	// }
 
 	/**
 	 * 跟新规则的scores
@@ -159,24 +172,24 @@ public class GrammarTrainer
 	 * @param g
 	 *            语法
 	 */
-	public static void refreshRuleScore(Grammar g)
+	public static void recalculateRuleScore(Grammar g)
 	{
 		double newScore;
 		double denominator;
 		for (BinaryRule bRule : g.bRules)
 		{
 
-			int pNumSub = bRule.getCountExpectation().length;
-			int lCNumSub = bRule.getCountExpectation()[0].length;
-			int rCNumSub = bRule.getCountExpectation()[0][0].length;
+			int pNumSub = g.nonterminalTable.getNumSubsymbolArr().get(bRule.getParent());
+			int lCNumSub = g.nonterminalTable.getNumSubsymbolArr().get(bRule.getLeftChild());
+			int rCNumSub = g.nonterminalTable.getNumSubsymbolArr().get(bRule.getRightChild());
 
 			for (int i = 0; i < pNumSub; i++)
 			{
 
-				if (g.sameParentRulesCount.containsKey(bRule.parent)
-						&& g.sameParentRulesCount.get(bRule.parent)[i] != null)
+				if (ruleCounter.sameParentRulesCounter.containsKey(bRule.parent)
+						&& ruleCounter.sameParentRulesCounter.get(bRule.parent)[i] != null)
 				{
-					denominator = g.sameParentRulesCount.get(bRule.parent)[i];
+					denominator = ruleCounter.sameParentRulesCounter.get(bRule.parent)[i];
 				}
 				else
 				{
@@ -186,7 +199,7 @@ public class GrammarTrainer
 				{
 					for (int k = 0; k < rCNumSub; k++)
 					{
-						newScore = bRule.getCountExpectation()[i][j][k] / denominator;
+						newScore = ruleCounter.bRuleCounter.get(bRule)[i][j][k] / denominator;
 						if (newScore < Rule.rulethres)
 						{
 							newScore = 0.0;
@@ -201,14 +214,14 @@ public class GrammarTrainer
 
 		for (UnaryRule uRule : g.uRules)
 		{
-			int pNumSub = uRule.getCountExpectation().length;
-			int cNumSub = uRule.getCountExpectation()[0].length;
+			int pNumSub = g.nonterminalTable.getNumSubsymbolArr().get(uRule.getParent());
+			int cNumSub = g.nonterminalTable.getNumSubsymbolArr().get(uRule.getChild());
 			for (int i = 0; i < pNumSub; i++)
 			{
-				if (g.sameParentRulesCount.containsKey(uRule.parent)
-						&& g.sameParentRulesCount.get(uRule.parent)[i] != null)
+				if (ruleCounter.sameParentRulesCounter.containsKey(uRule.parent)
+						&& ruleCounter.sameParentRulesCounter.get(uRule.parent)[i] != null)
 				{
-					denominator = g.sameParentRulesCount.get(uRule.parent)[i];
+					denominator = ruleCounter.sameParentRulesCounter.get(uRule.parent)[i];
 				}
 				else
 				{
@@ -216,33 +229,31 @@ public class GrammarTrainer
 				}
 				for (int j = 0; j < cNumSub; j++)
 				{
-					newScore = uRule.getCountExpectation()[i][j] / denominator;
+					newScore = ruleCounter.uRuleCounter.get(uRule)[i][j] / denominator;
 					if (newScore < Rule.rulethres)
 					{
 						newScore = 0.0;
 					}
 					uRule.getScores().get(i).set(j, newScore);
-
 				}
 			}
 		}
 
 		for (PreterminalRule preRule : g.lexicon.getPreRules())
 		{
-			preRule.getCountExpectation();
-			int pNumSub = preRule.getCountExpectation().length;
+			int pNumSub = g.nonterminalTable.getNumSubsymbolArr().get(preRule.parent);
 			for (int i = 0; i < pNumSub; i++)
 			{
-				if (g.sameParentRulesCount.containsKey(preRule.parent)
-						&& g.sameParentRulesCount.get(preRule.parent)[i] != null)
+				if (ruleCounter.sameParentRulesCounter.containsKey(preRule.parent)
+						&& ruleCounter.sameParentRulesCounter.get(preRule.parent)[i] != null)
 				{
-					denominator = g.sameParentRulesCount.get(preRule.parent)[i];
+					denominator = ruleCounter.sameParentRulesCounter.get(preRule.parent)[i];
 				}
 				else
 				{
 					denominator = calculateSameParentRuleCount(g, preRule.parent, i);
 				}
-				newScore = preRule.getCountExpectation()[i] / denominator;
+				newScore = ruleCounter.preRuleCounter.get(preRule)[i] / denominator;
 				if (newScore < Rule.rulethres)
 				{
 					newScore = 0.0;
@@ -257,14 +268,14 @@ public class GrammarTrainer
 	 */
 	public static Double calculateSameParentRuleCount(Grammar g, int parent, int pSubSymbolIndex)
 	{
-		if (!g.sameParentRulesCount.containsKey((short) parent)
-				|| g.sameParentRulesCount.get((short) parent)[pSubSymbolIndex] == null)
+		if (!ruleCounter.sameParentRulesCounter.containsKey((short) parent)
+				|| ruleCounter.sameParentRulesCounter.get((short) parent)[pSubSymbolIndex] == null)
 		{
 			double ruleCount = 0.0;
 			if (g.bRuleBySameHead.containsKey((short) parent))
 				for (Map.Entry<BinaryRule, BinaryRule> entry : g.bRuleBySameHead.get((short) parent).entrySet())
 				{
-					double[][][] count = entry.getValue().getCountExpectation();
+					double[][][] count = ruleCounter.bRuleCounter.get(entry.getValue());
 					for (int i = 0; i < count[pSubSymbolIndex].length; i++)
 					{
 						for (int j = 0; j < count[pSubSymbolIndex][i].length; j++)
@@ -276,7 +287,7 @@ public class GrammarTrainer
 			if (g.uRuleBySameHead.containsKey((short) parent))
 				for (Map.Entry<UnaryRule, UnaryRule> entry : g.uRuleBySameHead.get((short) parent).entrySet())
 				{
-					double[][] count = entry.getValue().getCountExpectation();
+					double[][] count = ruleCounter.uRuleCounter.get(entry.getValue());
 					for (int i = 0; i < count[pSubSymbolIndex].length; i++)
 					{
 						ruleCount = ruleCount + count[pSubSymbolIndex][i];
@@ -286,24 +297,24 @@ public class GrammarTrainer
 				for (Map.Entry<PreterminalRule, PreterminalRule> entry : g.preRuleBySameHead.get((short) parent)
 						.entrySet())
 				{
-					double[] count = entry.getValue().getCountExpectation();
+					double[] count = ruleCounter.preRuleCounter.get(entry.getValue());
 					ruleCount = ruleCount + count[pSubSymbolIndex];
 				}
-			if (g.sameParentRulesCount.containsKey((short) parent))
+			if (ruleCounter.sameParentRulesCounter.containsKey((short) parent))
 			{
-				g.sameParentRulesCount.get((short) parent)[pSubSymbolIndex] = ruleCount;
+				ruleCounter.sameParentRulesCounter.get((short) parent)[pSubSymbolIndex] = ruleCount;
 			}
 			else
 			{
 				Double[] countArr = new Double[g.nonterminalTable.getNumSubsymbolArr().get(parent)];
 				countArr[pSubSymbolIndex] = ruleCount;
-				g.sameParentRulesCount.put((short) parent, countArr);
+				ruleCounter.sameParentRulesCounter.put((short) parent, countArr);
 			}
 			return ruleCount;
 		}
 		else
 		{
-			return g.sameParentRulesCount.get((short) parent)[pSubSymbolIndex];
+			return ruleCounter.sameParentRulesCounter.get((short) parent)[pSubSymbolIndex];
 		}
 	}
 }

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Lexicon.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Lexicon.java
@@ -1,6 +1,5 @@
 package com.lc.nlp4han.constituent.unlex;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,8 +49,7 @@ public class Lexicon
 	{
 		for (int i = 0; i < tagWithRareWord.size(); i++)
 		{
-			scores[i] = BigDecimal.valueOf(rareWordCount.get(i))
-					.divide(BigDecimal.valueOf(allRareWord), 15, BigDecimal.ROUND_HALF_UP).doubleValue();
+			scores[i] = rareWordCount.get(i) / allRareWord;
 		}
 	}
 
@@ -60,12 +58,12 @@ public class Lexicon
 		return dictionary.containsKey(word);
 	}
 
-	public HashMap<String,Integer> getDictionary()
+	public HashMap<String, Integer> getDictionary()
 	{
 		return dictionary;
 	}
 
-	public void setDictionary(HashMap<String,Integer> dictionary)
+	public void setDictionary(HashMap<String, Integer> dictionary)
 	{
 		this.dictionary = dictionary;
 	}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/NonterminalTable.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/NonterminalTable.java
@@ -11,8 +11,6 @@ import java.util.HashMap;
 public class NonterminalTable
 {
 	private HashMap<String, Short> str_intMap;// "ROOT" - 0
-
-
 	private HashMap<Short, String> int_strMap;
 	private short numInitialSymbol;//二叉化后得到的所有非终结符个数
 	private ArrayList<Short> intValueOfPreterminalArr;

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedCrossValidator.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedCrossValidator.java
@@ -1,0 +1,61 @@
+package com.lc.nlp4han.constituent.unlex;
+
+import java.io.IOException;
+
+import com.lc.nlp4han.constituent.ConstituentMeasure;
+import com.lc.nlp4han.constituent.ConstituentTree;
+import com.lc.nlp4han.constituent.pcfg.ConstituentTreeStream;
+import com.lc.nlp4han.constituent.pcfg.PCFG;
+import com.lc.nlp4han.ml.util.CrossValidationPartitioner;
+import com.lc.nlp4han.ml.util.ObjectStream;
+
+/**
+ * 交叉验证类
+ * 
+ * @author 王宁
+ */
+public class ParentLabelAddedCrossValidator
+{
+
+	public void evaluate(ObjectStream<String> sentenceStream, int nFolds, ConstituentMeasure measure,
+			double pruneThreshold, boolean secondPrune, boolean prior) throws IOException
+	{
+
+		CrossValidationPartitioner<String> partitioner = new CrossValidationPartitioner<String>(sentenceStream, nFolds);
+		int run = 1;
+		double totalTime = 0;
+		while (partitioner.hasNext())
+		{
+			System.out.println("Run" + run + "...");
+			long start = System.currentTimeMillis();
+			CrossValidationPartitioner.TrainingSampleStream<String> trainingSampleStream = partitioner.next();
+			TreeBank treeBank = new TreeBank();
+			String expression;
+			while ((expression = trainingSampleStream.read()) != null)
+			{
+				treeBank.addTree(expression, true);
+			}
+			GrammarExtractor gExtractor = new GrammarExtractor(treeBank);
+			Grammar g = gExtractor.getGrammar(1);
+			PCFG pcfg = g.getPCFG();
+			System.out.println("训练学习时间：" + (System.currentTimeMillis() - start) + "ms");
+			long start2 = System.currentTimeMillis();
+			ParentLabelAddedEvaluator evaluator = new ParentLabelAddedEvaluator(pcfg, pruneThreshold, secondPrune,
+					prior);
+			evaluator.setMeasure(new ConstituentMeasure());
+			ObjectStream<ConstituentTree> sampleStream = new ConstituentTreeStream(
+					trainingSampleStream.getTestSampleStream());
+			evaluator.evaluate(sampleStream);
+			System.out.println("解析评价时间：" + (System.currentTimeMillis() - start2) + "ms");
+			totalTime += (System.currentTimeMillis() - start);
+
+			System.out.println(measure);
+			g = null;
+			pcfg = null;
+			treeBank = null;
+			gExtractor = null;
+			run++;
+		}
+		System.out.println("总体时间： " + totalTime + "ms");
+	}
+}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedCrossValidatorTool.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedCrossValidatorTool.java
@@ -1,0 +1,78 @@
+package com.lc.nlp4han.constituent.unlex;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import com.lc.nlp4han.constituent.ConstituentMeasure;
+import com.lc.nlp4han.constituent.PlainTextByTreeStream;
+import com.lc.nlp4han.ml.util.FileInputStreamFactory;
+import com.lc.nlp4han.ml.util.ObjectStream;
+
+/**
+ * 交叉验证应用
+ * 
+ * @author 王宁
+ */
+public class ParentLabelAddedCrossValidatorTool
+{
+	private static void usage()
+	{
+		System.out.println(ParentLabelAddedCrossValidatorTool.class.getName()
+				+ " -train <corpusFile>  [-encoding <encoding>] [-folds <nFolds>] " + "[-em <emIterations>]");
+	}
+
+	public static void main(String[] args)
+	{
+		if (args.length < 1)
+		{
+			usage();
+
+			return;
+		}
+		String corpusFile = null;
+		int folds = 10;
+		String encoding = "UTF-8";
+		int emIterations = 50;
+		boolean addParentLabel = true;
+		double pruneThreshold = 0.0001;
+		boolean secondPrune = false;
+		boolean prior = false;
+		for (int i = 0; i < args.length; i++)
+		{
+			if (args[i].equals("-train"))
+			{
+				corpusFile = args[i + 1];
+				i++;
+			}
+			if (args[i].equals("-encoding"))
+			{
+				encoding = args[i + 1];
+				i++;
+			}
+			if (args[i].equals("-folds"))
+			{
+				folds = Integer.parseInt(args[i + 1]);
+				i++;
+			}
+			if (args[i].equals("-em"))
+			{
+				emIterations = Integer.parseInt(args[i + 1]);
+				i++;
+			}
+		}
+		try
+		{
+			ObjectStream<String> sentenceStream = new PlainTextByTreeStream(
+					new FileInputStreamFactory(new File(corpusFile)), encoding);
+
+			ConstituentMeasure measure = new ConstituentMeasure();
+			ParentLabelAddedCrossValidator crossValidator = new ParentLabelAddedCrossValidator();
+			crossValidator.evaluate(sentenceStream, folds, measure, pruneThreshold, secondPrune, prior);
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+	}
+}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedCrossValidatorTool.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedCrossValidatorTool.java
@@ -1,7 +1,6 @@
 package com.lc.nlp4han.constituent.unlex;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import com.lc.nlp4han.constituent.ConstituentMeasure;
@@ -19,7 +18,7 @@ public class ParentLabelAddedCrossValidatorTool
 	private static void usage()
 	{
 		System.out.println(ParentLabelAddedCrossValidatorTool.class.getName()
-				+ " -train <corpusFile>  [-encoding <encoding>] [-folds <nFolds>] " + "[-em <emIterations>]");
+				+ " -train <corpusFile>  [-encoding <encoding>] [-folds <nFolds>] ");
 	}
 
 	public static void main(String[] args)
@@ -27,14 +26,11 @@ public class ParentLabelAddedCrossValidatorTool
 		if (args.length < 1)
 		{
 			usage();
-
 			return;
 		}
 		String corpusFile = null;
 		int folds = 10;
 		String encoding = "UTF-8";
-		int emIterations = 50;
-		boolean addParentLabel = true;
 		double pruneThreshold = 0.0001;
 		boolean secondPrune = false;
 		boolean prior = false;
@@ -53,11 +49,6 @@ public class ParentLabelAddedCrossValidatorTool
 			if (args[i].equals("-folds"))
 			{
 				folds = Integer.parseInt(args[i + 1]);
-				i++;
-			}
-			if (args[i].equals("-em"))
-			{
-				emIterations = Integer.parseInt(args[i + 1]);
 				i++;
 			}
 		}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedEvalTool.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedEvalTool.java
@@ -14,22 +14,22 @@ import com.lc.nlp4han.ml.util.ObjectStream;
 /**
  * @author 王宁
  */
-public class UnlexEvalTool
+public class ParentLabelAddedEvalTool
 {
 	private static void usage()
 	{
-		System.out.println(UnlexEvalTool.class.getName() + "\n"
+		System.out.println(ParentLabelAddedEvalTool.class.getName() + "\n"
 				+ "-train <trainFile> -gold <goldFile> [-trainEncoding <trainEncoding>] [-goldEncoding <trainEncoding>] [-em <emIterations>]");
 	}
 
 	public static void eval(String trainF, String goldF, String trainEn, String goldEn, int iterations,
-			double pruneThreshold, boolean secondPrune,boolean prior) throws IOException
+			double pruneThreshold, boolean secondPrune, boolean prior) throws IOException
 	{
-		Grammar g = GrammarExtractorTool.getGrammar(1, 0.5, 50, true, Lexicon.DEFAULT_RAREWORD_THRESHOLD, trainF,
-				trainEn);
+		long start = System.currentTimeMillis();
+		Grammar g = new GrammarExtractor(trainF, true, trainEn).getGrammar(1);
 		PCFG p2nf = g.getPCFG();
-
-		UnlexEvaluator evaluator = new UnlexEvaluator(p2nf,pruneThreshold,secondPrune,prior);
+		long end = System.currentTimeMillis();
+		ParentLabelAddedEvaluator evaluator = new ParentLabelAddedEvaluator(p2nf, pruneThreshold, secondPrune, prior);
 
 		ConstituentMeasure measure = new ConstituentMeasure();
 		evaluator.setMeasure(measure);
@@ -39,6 +39,7 @@ public class UnlexEvalTool
 		evaluator.evaluate(sampleStream);
 
 		ConstituentMeasure measureRes = evaluator.getMeasure();
+		System.out.println(end - start);
 		System.out.println(measureRes);
 	}
 
@@ -50,7 +51,7 @@ public class UnlexEvalTool
 		String goldEncoding = "utf-8";
 		double pruneThreshold = 0.0001;
 		boolean secondPrune = false;
-		boolean prior=false;
+		boolean prior = false;
 		int iterations = 50;// em算法迭代次数
 		for (int i = 0; i < args.length; i++)
 		{
@@ -103,7 +104,8 @@ public class UnlexEvalTool
 		}
 		try
 		{
-			eval(trainFilePath, goldFilePath, trainEncoding, goldEncoding, iterations, pruneThreshold, secondPrune,prior);
+			eval(trainFilePath, goldFilePath, trainEncoding, goldEncoding, iterations, pruneThreshold, secondPrune,
+					prior);
 		}
 		catch (IOException e)
 		{

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedEvaluator.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ParentLabelAddedEvaluator.java
@@ -15,7 +15,7 @@ import com.lc.nlp4han.ml.util.Evaluator;
 * @author 王宁
 * 
 */
-public class UnlexEvaluator extends Evaluator<ConstituentTree>
+public class ParentLabelAddedEvaluator extends Evaluator<ConstituentTree>
 {
 	/**
 	 * 句法分析模型得到一颗句法树
@@ -40,12 +40,12 @@ public class UnlexEvaluator extends Evaluator<ConstituentTree>
 		this.measure = measure;
 	}
 
-	public UnlexEvaluator(ConstituentParser cky)
+	public ParentLabelAddedEvaluator(ConstituentParser cky)
 	{
 		this.cky = cky;
 	}
 
-	public UnlexEvaluator(PCFG p2nf,double pruneThreshold,boolean secondPrune,boolean prior)
+	public ParentLabelAddedEvaluator(PCFG p2nf,double pruneThreshold,boolean secondPrune,boolean prior)
 	{
 		this.cky = new ConstituentParserCKYP2NF(p2nf,pruneThreshold,secondPrune,prior);
 	}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/PreterminalRule.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/PreterminalRule.java
@@ -15,7 +15,6 @@ public class PreterminalRule extends Rule
 {
 	String word;
 	LinkedList<Double> scores = new LinkedList<Double>();
-	double[] countExpectation = null;
 
 	public PreterminalRule(short parent, String word)
 	{
@@ -123,16 +122,6 @@ public class PreterminalRule extends Rule
 	public void setScores(LinkedList<Double> scores)
 	{
 		this.scores = scores;
-	}
-
-	public double[] getCountExpectation()
-	{
-		return countExpectation;
-	}
-
-	public void setCountExpectation(double[] countExpectation)
-	{
-		this.countExpectation = countExpectation;
 	}
 
 	@Override

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Rule.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/Rule.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
  */
 public abstract class Rule
 {
-	// public static NonterminalTable nonterminalTable;
+	public static double rulethres = 1.0e-30;// 小于该值均赋值为0.0
 	protected short parent;
 
 	public void split()

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/RuleCounter.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/RuleCounter.java
@@ -1,0 +1,140 @@
+package com.lc.nlp4han.constituent.unlex;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+
+/**
+ * 记录规则的期望次数
+ * 
+ * @author 王宁
+ */
+public class RuleCounter
+{
+	protected HashMap<BinaryRule, double[][][]> bRuleCounter;
+	protected HashMap<UnaryRule, double[][]> uRuleCounter;
+	protected HashMap<PreterminalRule, double[]> preRuleCounter;
+	protected HashMap<Short, Double[]> sameParentRulesCounter;// <parent,[ParentSubIndex,sum]>
+
+	public RuleCounter()
+	{
+		bRuleCounter = new HashMap<>();
+		uRuleCounter = new HashMap<>();
+		preRuleCounter = new HashMap<>();
+		sameParentRulesCounter = new HashMap<>();
+	}
+
+	public void calRuleExpectation(Grammar g, TreeBank treeBank)
+	{
+		for (AnnotationTreeNode tree : treeBank.getTreeBank())
+		{
+			TreeBank.calculateInnerScore(g, tree);
+			TreeBank.calculateOuterScore(g, tree);
+			refreshRuleCountExpectation(g, tree, tree);
+			tree.forgetIOScoreAndScale();
+		}
+	}
+
+	public void refreshRuleCountExpectation(Grammar g, AnnotationTreeNode root, AnnotationTreeNode tree)
+	{
+
+		if (tree.getChildren().size() == 0 || tree == null)
+			return;
+		double scalingFactor;
+		if (tree.getChildren().size() == 2)
+		{
+
+			AnnotationTreeNode lC = tree.getChildren().get(0);
+			AnnotationTreeNode rC = tree.getChildren().get(1);
+			BinaryRule rule = new BinaryRule(tree.getLabel().getSymbol(), lC.getLabel().getSymbol(),
+					rC.getLabel().getSymbol());
+			rule = g.bRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule);
+			LinkedList<LinkedList<LinkedList<Double>>> scores = rule.getScores();
+			double[][][] count;
+			if (!bRuleCounter.containsKey(rule))
+			{
+				count = new double[tree.getLabel().getNumSubSymbol()][lC.getLabel().getNumSubSymbol()][rC.getLabel()
+						.getNumSubSymbol()];
+				bRuleCounter.put(rule, count);
+			}
+			else
+			{
+				count = bRuleCounter.get(rule);
+			}
+			scalingFactor = ScalingTools.calcScaleFactor(tree.getLabel().getOuterScale() + lC.getLabel().getInnerScale()
+					+ rC.getLabel().getInnerScale() - root.getLabel().getInnerScale());
+			for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
+			{
+				for (int j = 0; j < tree.getChildren().get(0).getLabel().getNumSubSymbol(); j++)
+				{
+					for (int k = 0; k < tree.getChildren().get(1).getLabel().getNumSubSymbol(); k++)
+					{
+						count[i][j][k] = count[i][j][k]
+								+ (scores.get(i).get(j).get(k) * lC.getLabel().getInnerScores()[j]
+										/ root.getLabel().getInnerScores()[0] * rC.getLabel().getInnerScores()[k]
+										* scalingFactor * tree.getLabel().getOuterScores()[i]);
+					}
+				}
+			}
+		}
+		else if (tree.getChildren().size() == 1 && tree.getChildren().get(0).getLabel().getWord() == null)
+		{
+			AnnotationTreeNode child = tree.getChildren().get(0);
+			UnaryRule rule = new UnaryRule(tree.getLabel().getSymbol(), child.getLabel().getSymbol());
+			rule = g.uRuleBySameHead.get(tree.getLabel().getSymbol()).get(rule);
+			LinkedList<LinkedList<Double>> scores = rule.getScores();
+			double[][] count;
+			if (!uRuleCounter.containsKey(rule))
+			{
+				count = new double[tree.getLabel().getNumSubSymbol()][tree.getChildren().get(0).getLabel()
+						.getNumSubSymbol()];
+				uRuleCounter.put(rule, count);
+			}
+			else
+			{
+				count = uRuleCounter.get(rule);
+			}
+			scalingFactor = ScalingTools.calcScaleFactor(tree.getLabel().getOuterScale()
+					+ child.getLabel().getInnerScale() - root.getLabel().getInnerScale());
+			for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
+			{
+				for (int j = 0; j < tree.getChildren().get(0).getLabel().getNumSubSymbol(); j++)
+				{
+					count[i][j] = count[i][j] + (scores.get(i).get(j) * child.getLabel().getInnerScores()[j]
+							/ root.getLabel().getInnerScores()[0] * scalingFactor
+							* tree.getLabel().getOuterScores()[i]);
+				}
+			}
+		}
+		else if (tree.isPreterminal())
+		{
+			PreterminalRule rule = new PreterminalRule(tree.getLabel().getSymbol(),
+					tree.getChildren().get(0).getLabel().getWord());
+			rule = g.preRuleBySameHead.get(rule.getParent()).get(rule);
+			LinkedList<Double> scores = rule.getScores();
+			double[] count;
+			if (!preRuleCounter.containsKey(rule))
+			{
+				count = new double[tree.getLabel().getNumSubSymbol()];
+				preRuleCounter.put(rule, count);
+			}
+			else
+			{
+				count = preRuleCounter.get(rule);
+			}
+			scalingFactor = ScalingTools
+					.calcScaleFactor(tree.getLabel().getOuterScale() - root.getLabel().getInnerScale());
+			for (int i = 0; i < tree.getLabel().getNumSubSymbol(); i++)
+			{
+				count[i] = count[i] + (scores.get(i) / root.getLabel().getInnerScores()[0] * scalingFactor
+						* tree.getLabel().getOuterScores()[i]);
+			}
+		}
+		else if (tree.getChildren().size() > 2)
+			throw new Error("error tree:more than 2 children.");
+
+		for (AnnotationTreeNode child : tree.getChildren())
+		{
+			refreshRuleCountExpectation(g, root, child);
+		}
+	}
+}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ScalingTools.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/ScalingTools.java
@@ -1,0 +1,81 @@
+package com.lc.nlp4han.constituent.unlex;
+
+/**
+ * 用来对数据缩放,任何一个进行缩放了的数据都由缩放后大小和缩放比例组成。所以一个缩放后的数据的原始数据=缩放后大小*缩放比例。 缩放比例 =
+ * Math.exp(100)^scaleFactor.所以原始数据 = 缩放后大小*(Math.exp(100)^scaleFactor)。
+ * 
+ * @author 王宁
+ */
+public class ScalingTools
+{
+	public static double base = Math.exp(100);
+
+	/**
+	 * 计算缩放的真实比例
+	 * 
+	 * @param 缩放比例
+	 * @return
+	 */
+	public static double calcScaleFactor(double logScale)
+	{
+		if (logScale == Integer.MIN_VALUE || logScale == Integer.MAX_VALUE)
+		{
+			return 0.0;
+		}
+
+		return Math.pow(base, logScale);
+	}
+
+	/**
+	 * 将已经缩放的数据进一步缩放，一组数据依照最大的数据的缩放比例进行缩放
+	 * 
+	 * @param scores
+	 *            缩放后的数据
+	 * @param previousScale
+	 *            之前缩放的比例,之前没有进行缩放则为0
+	 * @return 进一步缩放后完整的缩放比例的log值（以Math.exp(100)为底）
+	 */
+	public static int scaleArray(int previousScale, Double... scores)
+	{
+		if (previousScale == Integer.MIN_VALUE || previousScale == Integer.MAX_VALUE)
+		{
+			return previousScale;
+		}
+		int logScale = 0;// 本次缩放的真实比例的log值
+		double scale = 1.0;// 本次缩放的真实比例
+		double max = Double.NEGATIVE_INFINITY;
+		for (int i = 0; i < scores.length; i++)
+		{
+			if (scores[i] > max)
+			{
+				max = scores[i];
+			}
+		}
+		if (max == Double.POSITIVE_INFINITY)
+		{
+			return 0;
+		}
+		if (max == 0)
+			return previousScale;
+		while (max > base)
+		{
+			max /= base;
+			scale *= base;
+			logScale += 1;
+		}
+		while (max > 0.0 && max < 1.0 / base)
+		{
+			max *= base;
+			scale /= base;
+			logScale -= 1;
+		}
+		if (logScale != 0)
+		{
+			for (int i = 0; i < scores.length; i++)
+			{
+				scores[i] /= scale;
+			}
+		}
+		return previousScale + logScale;
+	}
+}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/TreeBank.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/TreeBank.java
@@ -334,6 +334,15 @@ public class TreeBank
 		}
 	}
 
+	public void calIOScore(Grammar g)
+	{
+		for (AnnotationTreeNode tree : treeBank)
+		{
+			TreeBank.calculateInnerScore(g, tree);
+			TreeBank.calculateOuterScore(g, tree);
+		}
+	}
+
 	public void forgetIOScoreAndScale()
 	{
 		for (AnnotationTreeNode tree : treeBank)

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/TreeBank.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/TreeBank.java
@@ -1,8 +1,15 @@
 package com.lc.nlp4han.constituent.unlex;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
+
+import com.lc.nlp4han.constituent.BracketExpUtil;
+import com.lc.nlp4han.constituent.PlainTextByTreeStream;
+import com.lc.nlp4han.constituent.TreeNode;
+import com.lc.nlp4han.ml.util.FileInputStreamFactory;
 
 /**
  * 表示树库
@@ -11,13 +18,48 @@ import java.util.LinkedList;
  */
 public class TreeBank
 {
-	public static NonterminalTable nonterminalTable;
+	public NonterminalTable nonterminalTable;
 	private ArrayList<AnnotationTreeNode> treeBank;
 
-	public TreeBank(ArrayList<AnnotationTreeNode> treeBank, NonterminalTable nonterminalTable)
+	public TreeBank(String treeBankPath, boolean addParentLabel, String encoding) throws IOException
 	{
-		this.treeBank = treeBank;
-		this.nonterminalTable = nonterminalTable;
+		this.treeBank = new ArrayList<AnnotationTreeNode>();
+		this.nonterminalTable = new NonterminalTable();
+		init(treeBankPath, addParentLabel, encoding);
+	}
+
+	public TreeBank()
+	{
+		this.treeBank = new ArrayList<AnnotationTreeNode>();
+		this.nonterminalTable = new NonterminalTable();
+	}
+
+	public void init(String treeBankPath, boolean addParentLabel, String encoding) throws IOException
+	{
+		PlainTextByTreeStream stream = new PlainTextByTreeStream(new FileInputStreamFactory(new File(treeBankPath)),
+				encoding);
+		String expression = stream.read();
+		while (expression != "" && expression != null)// 用来得到树库对应的所有结构树Tree<String>
+		{
+			expression = expression.trim();
+			if (!expression.equals(""))
+			{
+				this.addTree(expression, addParentLabel);
+			}
+			expression = stream.read();
+		}
+		stream.close();
+	}
+
+	public void addTree(String expression, boolean addParentLabel)
+	{
+		TreeNode tree = BracketExpUtil.generateTree(expression);
+		tree = TreeUtil.removeL2LRule(tree);
+		if (addParentLabel)
+			tree = TreeUtil.addParentLabel(tree);
+		tree = Binarization.binarizeTree(tree);
+		AnnotationTreeNode annotatedTree = AnnotationTreeNode.getInstance(tree, this.nonterminalTable);
+		treeBank.add(annotatedTree);
 	}
 
 	/**
@@ -26,7 +68,7 @@ public class TreeBank
 	 * @param node
 	 * @return
 	 */
-	public static double calculateSentenceSocre(AnnotationTreeNode node)
+	public static double calLogSentenceSocre(AnnotationTreeNode node)
 	{
 		if (node.getLabel().getInnerScores() == null || node.getLabel().getOuterScores() == null)
 			throw new Error("没有计算树上节点的内外向概率。");
@@ -39,11 +81,13 @@ public class TreeBank
 		{
 			sentenceScore += innerScore[i] * outerScores[i];
 		}
-		return sentenceScore;
+		double logSenScore = Math.log(sentenceScore)
+				+ 100 * (node.getLabel().getInnerScale() + node.getLabel().getOuterScale());
+		return logSenScore;
 	}
 
 	/**
-	 * 计算树上所有节点的所有隐藏节点的内向概率
+	 * 计算树上所有节点的所有隐藏节点的内向概率及缩放比例
 	 * 
 	 * @param g
 	 *            语法
@@ -70,15 +114,10 @@ public class TreeBank
 				int length = tree.getLabel().getNumSubSymbol();
 
 				PreterminalRule realRule = g.preRuleBySameHead.get(tree.getLabel().getSymbol()).get(tempPreRule);
-				tree.getLabel().setInnerScores(realRule.getScores().toArray(new Double[length]));
-				// for (int i = 0; i < tree.getLabel().getInnerScores().length; i++)
-				// {
-				// System.out.println(nonterminalTable.stringValue(tree.getLabel().getSymbol())
-				// + "["
-				// + tree.getLabel().getSpanFrom() + "," + tree.getLabel().getSpanTo() + "]" +
-				// "innerScore_"
-				// + i + ":" + tree.getLabel().getInnerScores()[i]);
-				// }
+				Double[] newScores = realRule.getScores().toArray(new Double[length]);
+				// 预终结符号的内向概率不用缩放，最小为e^-30
+				tree.getLabel().setInnerScores(newScores);
+				tree.getLabel().setInnerScale(0);
 
 			}
 			else
@@ -98,7 +137,7 @@ public class TreeBank
 					LinkedList<LinkedList<Double>> uRuleScores = g.uRuleBySameHead.get(tree.getLabel().getSymbol())
 							.get(tempUnaryRule).getScores();
 					Double[] innerScores = new Double[tree.getLabel().getNumSubSymbol()];
-					tree.getLabel().setInnerScores(innerScores);
+					int childInnerScale = tree.getChildren().get(0).getLabel().getInnerScale();
 					for (int i = 0; i < innerScores.length; i++)
 					{
 						double innerScores_Ai = 0.0;
@@ -109,12 +148,10 @@ public class TreeBank
 							innerScores_Ai = innerScores_Ai + (A_i2B_j * B_jInnerScore);
 						}
 						innerScores[i] = innerScores_Ai;
-						// System.out.println(nonterminalTable.stringValue(tree.getLabel().getSymbol())
-						// + "["
-						// + tree.getLabel().getSpanFrom() + "," + tree.getLabel().getSpanTo() + "]"
-						// + "innerScore_" + i + ":" + tree.getLabel().getInnerScores()[i]);
 					}
-					// tree.getLabel().setInnerScores(innerScores);
+					int newScale = ScalingTools.scaleArray(childInnerScale, innerScores);
+					tree.getLabel().setInnerScores(innerScores);
+					tree.getLabel().setInnerScale(newScale);
 				}
 				else
 				{
@@ -130,7 +167,8 @@ public class TreeBank
 					LinkedList<LinkedList<LinkedList<Double>>> bRuleScores = g.bRuleBySameHead
 							.get(tree.getLabel().getSymbol()).get(tempBRule).getScores();
 					Double[] innerScores = new Double[tree.getLabel().getNumSubSymbol()];
-					tree.getLabel().setInnerScores(innerScores);
+					int leftChildInnerScale = tree.getChildren().get(0).getLabel().getInnerScale();
+					int rightChildInnerScale = tree.getChildren().get(1).getLabel().getInnerScale();
 					for (int i = 0; i < innerScores.length; i++)
 					{
 						double innerScores_Ai = 0.0;
@@ -146,12 +184,10 @@ public class TreeBank
 							}
 						}
 						innerScores[i] = innerScores_Ai;
-						// System.out.println(nonterminalTable.stringValue(tree.getLabel().getSymbol())
-						// + "["
-						// + tree.getLabel().getSpanFrom() + "," + tree.getLabel().getSpanTo() + "]"
-						// + "innerScore_" + i + ":" + tree.getLabel().getInnerScores()[i]);
 					}
-					// tree.getLabel().setInnerScores(innerScores);
+					int newScale = ScalingTools.scaleArray(leftChildInnerScale + rightChildInnerScale, innerScores);
+					tree.getLabel().setInnerScores(innerScores);
+					tree.getLabel().setInnerScale(newScale);
 				}
 				else
 				{
@@ -162,7 +198,6 @@ public class TreeBank
 				throw new Error("Error tree: more than two children.");
 			}
 		}
-
 	}
 
 	/**
@@ -190,6 +225,7 @@ public class TreeBank
 			Double[] array = new Double[treeNode.getLabel().getNumSubSymbol()];
 			Arrays.fill(array, 1.0);
 			treeNode.getLabel().setOuterScores(array);
+			treeNode.getLabel().setOuterScale(0);
 		}
 		else
 		{
@@ -204,6 +240,7 @@ public class TreeBank
 					LinkedList<LinkedList<Double>> uRuleScores = g.uRuleBySameHead.get(parent.getLabel().getSymbol())
 							.get(tempUnaryRule).getScores();
 					Double[] outerScores = new Double[treeNode.getLabel().getNumSubSymbol()];
+					int parentOuterScale = parent.getLabel().getOuterScale();
 					for (int j = 0; j < outerScores.length; j++)
 					{
 						double outerScores_Bj = 0.0;
@@ -214,13 +251,10 @@ public class TreeBank
 							outerScores_Bj = outerScores_Bj + (A_i2B_j * A_iOuterScore);
 						}
 						outerScores[j] = outerScores_Bj;
-						// System.out.println(nonterminalTable.stringValue(treeNode.getLabel().getSymbol())
-						// + "["
-						// + treeNode.getLabel().getSpanFrom() + "," + treeNode.getLabel().getSpanTo() +
-						// "]"
-						// + "outerScore_" + j + ":" + outerScores_Bj);
 					}
+					int newScale = ScalingTools.scaleArray(parentOuterScale, outerScores);
 					treeNode.getLabel().setOuterScores(outerScores);
+					treeNode.getLabel().setOuterScale(newScale);
 				}
 				else
 				{
@@ -232,15 +266,19 @@ public class TreeBank
 				// 获取兄弟节点的内向概率
 				Double[] siblingNode_InScore;
 				final BinaryRule tempBRule;
+				int siblingInnerScale;
+				int parentOuterScale = parent.getLabel().getOuterScale();
 				if (parent.getChildren().get(0) == treeNode)
 				{
 					siblingNode_InScore = parent.getChildren().get(1).getLabel().getInnerScores();
+					siblingInnerScale = parent.getChildren().get(1).getLabel().getInnerScale();
 					tempBRule = new BinaryRule(parent.getLabel().getSymbol(), treeNode.getLabel().getSymbol(),
 							parent.getChildren().get(1).getLabel().getSymbol());
 				}
 				else
 				{
 					siblingNode_InScore = parent.getChildren().get(0).getLabel().getInnerScores();
+					siblingInnerScale = parent.getChildren().get(0).getLabel().getInnerScale();
 					tempBRule = new BinaryRule(parent.getLabel().getSymbol(),
 							parent.getChildren().get(0).getLabel().getSymbol(), treeNode.getLabel().getSymbol());
 				}
@@ -274,14 +312,11 @@ public class TreeBank
 
 							}
 						}
-						// System.out.println(nonterminalTable.stringValue(treeNode.getLabel().getSymbol())
-						// + "["
-						// + treeNode.getLabel().getSpanFrom() + "," + treeNode.getLabel().getSpanTo() +
-						// "]"
-						// + "outerScore_" + i + ":" + outerScoreB_i);
 						outerScores[i] = outerScoreB_i;
 					}
+					int newScale = ScalingTools.scaleArray(parentOuterScale + siblingInnerScale, outerScores);
 					treeNode.getLabel().setOuterScores(outerScores);
+					treeNode.getLabel().setOuterScale(newScale);
 				}
 				else
 				{
@@ -299,11 +334,11 @@ public class TreeBank
 		}
 	}
 
-	public void forgetIOScore()
+	public void forgetIOScoreAndScale()
 	{
 		for (AnnotationTreeNode tree : treeBank)
 		{
-			tree.forgetIOScore();
+			tree.forgetIOScoreAndScale();
 		}
 	}
 

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/UnaryRule.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/UnaryRule.java
@@ -35,7 +35,6 @@ public class UnaryRule extends Rule
 			int cNumSubSymbol = sameFather.size();
 			for (int j = cNumSubSymbol - 1; j >= 0; j--)
 			{
-
 				sameFather.add(j + 1, sameFather.get(j) / 2);
 				sameFather.set(j, sameFather.get(j + 1));
 			}

--- a/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/UnaryRule.java
+++ b/nlp4han-constituent/src/main/java/com/lc/nlp4han/constituent/unlex/UnaryRule.java
@@ -14,7 +14,6 @@ public class UnaryRule extends Rule
 {
 	private short child;
 	LinkedList<LinkedList<Double>> scores = new LinkedList<LinkedList<Double>>();// 保存规则例如Ai -> Bj 的概率
-	double[][] countExpectation = null;
 
 	public UnaryRule(short parent, short child)
 	{
@@ -45,9 +44,6 @@ public class UnaryRule extends Rule
 		if (parent != 0)
 			for (int i = pNumSubSymbol - 1; i >= 0; i--)
 			{
-				// scores.get(i).replaceAll(e -> BigDecimal.valueOf(e.doubleValue())
-				// .divide(BigDecimal.valueOf(2.0), 15,
-				// BigDecimal.ROUND_HALF_UP).doubleValue());
 				LinkedList<Double> sameChild = new LinkedList<>(scores.get(i));
 				scores.add(i + 1, sameChild);
 			}
@@ -187,16 +183,6 @@ public class UnaryRule extends Rule
 			return true;
 		else
 			return false;
-	}
-
-	public double[][] getCountExpectation()
-	{
-		return countExpectation;
-	}
-
-	public void setCountExpectation(double[][] countExpectation)
-	{
-		this.countExpectation = countExpectation;
 	}
 
 	@Override

--- a/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/AnnotationTreeNodeTest.java
+++ b/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/AnnotationTreeNodeTest.java
@@ -19,41 +19,28 @@ public class AnnotationTreeNodeTest
 		String[] sentences = { "(ROOT(IP(NP (PN i))(VP (VV like)(NP (DT the) (NN book)))))",
 				"(ROOT(VP (VT give)(NP (PN me))(NP (CD two) (NN books))))",
 				"(ROOT(IP(NP (DT the) (NN boy))(VP (VT saw)(NP (DT the) (NN dog)))))" };
-		ArrayList<AnnotationTreeNode> annotationTrees = new ArrayList<>();
-		TreeBank treeBank = new TreeBank(annotationTrees, new NonterminalTable());
+		TreeBank treeBank = new TreeBank();
 		for (int i = 0; i < sentences.length; i++)
 		{
-			TreeNode tree = BracketExpUtil.generateTree(sentences[i]);
-			tree = TreeUtil.removeL2LRule(tree);
-			tree = Binarization.binarizeTree(tree);
-			annotationTrees.add(AnnotationTreeNode.getInstance(tree, treeBank.getNonterminalTable()));
-			// AnnotationTreeNode中非叶子节点不包含label对应的字符串，只包含对应的整数。在打印时根据转换表格将整数转化回字符串
-			System.out.println(AnnotationTreeNode.printTree(annotationTrees.get(i), 0));
+			treeBank.addTree(sentences[i], false);
 		}
 	}
 
 	@Test
 	public void IOScoreTest()
 	{
-		GrammarExtractor gExtractor = new GrammarExtractor();
+
 		Boolean addParentLabel = false;
 		String[] sentences = { "(ROOT(IP(NP (PN i))(VP (VV like)(NP (DT the) (NN book)))))",
 				"(ROOT(VP (VT give)(NP (PN me))(NP (CD two) (NN books))))",
 				"(ROOT(IP(NP (DT the) (NN boy))(VP (VT saw)(NP (DT the) (NN dog)))))" };
-		ArrayList<AnnotationTreeNode> annotationTrees = new ArrayList<>();
-		TreeBank treeBank = new TreeBank(annotationTrees, new NonterminalTable());
+		TreeBank treeBank = new TreeBank();
 		for (int i = 0; i < sentences.length; i++)
 		{
-			TreeNode tree = BracketExpUtil.generateTree(sentences[i]);
-			tree = TreeUtil.removeL2LRule(tree);
-			if (addParentLabel)
-				tree = TreeUtil.addParentLabel(tree);
-			tree = Binarization.binarizeTree(tree);
-			annotationTrees.add(AnnotationTreeNode.getInstance(tree, treeBank.getNonterminalTable()));
+			treeBank.addTree(sentences[i], addParentLabel);
 		}
-		gExtractor.treeBank = treeBank;
-		gExtractor.initGrammar(1);
-		Grammar g = gExtractor.getGrammar(1, 0.5, 50);
+		GrammarExtractor gExtractor = new GrammarExtractor(treeBank);
+		Grammar g = gExtractor.getGrammar(1);
 		GrammarSpliter.splitGrammar(g, treeBank);
 		for (AnnotationTreeNode tree : treeBank.getTreeBank())
 		{

--- a/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/GrammarExtractorTest.java
+++ b/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/GrammarExtractorTest.java
@@ -14,30 +14,20 @@ import com.lc.nlp4han.constituent.unlex.GrammarExtractor;
 public class GrammarExtractorTest
 {
 	@Test
-	public void extractor()
+	public void extractor()// 测试提取初始语法
 	{
-		GrammarExtractor gExtractor = new GrammarExtractor();
+
 		Boolean addParentLabel = false;
 		String[] sentences = { "(ROOT(IP(NP (PN i))(VP (VV like)(NP (DT the) (NN book)))))",
 				"(ROOT(VP (VT give)(NP (PN me))(NP (CD two) (NN books))))",
 				"(ROOT(IP(NP (DT the) (NN boy))(VP (VT saw)(NP (DT the) (NN dog)))))" };
-		ArrayList<AnnotationTreeNode> annotationTrees = new ArrayList<>();
-		TreeBank treeBank = new TreeBank(annotationTrees, new NonterminalTable());
+		TreeBank treeBank = new TreeBank();
 		for (int i = 0; i < sentences.length; i++)
 		{
-			TreeNode tree = BracketExpUtil.generateTree(sentences[i]);
-			tree = TreeUtil.removeL2LRule(tree);
-			if (addParentLabel)
-				tree = TreeUtil.addParentLabel(tree);
-			tree = Binarization.binarizeTree(tree);
-			annotationTrees.add(AnnotationTreeNode.getInstance(tree, treeBank.getNonterminalTable()));
+			treeBank.addTree(sentences[i], addParentLabel);
 		}
-		gExtractor.treeBank = treeBank;
-		gExtractor.initGrammar(1);
+		GrammarExtractor gExtractor = new GrammarExtractor(treeBank);
+		Grammar g = gExtractor.getGrammar(1);
+		System.out.println();
 	}
-
-	// public static void main(String[] args)
-	// {
-	// new GrammarExtractorTest().extractor();
-	// }
 }

--- a/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/RuleTest.java
+++ b/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/RuleTest.java
@@ -13,25 +13,18 @@ public class RuleTest
 	@Test
 	public void ruleSplitTest()
 	{
-		GrammarExtractor gExtractor = new GrammarExtractor();
+
 		Boolean addParentLabel = false;
 		String[] sentences = { "(ROOT(IP(NP (PN i))(VP (VV like)(NP (DT the) (NN book)))))",
 				"(ROOT(VP (VT give)(NP (PN me))(NP (CD two) (NN books))))",
 				"(ROOT(IP(NP (DT the) (NN boy))(VP (VT saw)(NP (DT the) (NN dog)))))" };
-		ArrayList<AnnotationTreeNode> annotationTrees = new ArrayList<>();
-		TreeBank treeBank = new TreeBank(annotationTrees, new NonterminalTable());
+		TreeBank treeBank = new TreeBank();
 		for (int i = 0; i < sentences.length; i++)
 		{
-			TreeNode tree = BracketExpUtil.generateTree(sentences[i]);
-			tree = TreeUtil.removeL2LRule(tree);
-			if (addParentLabel)
-				tree = TreeUtil.addParentLabel(tree);
-			tree = Binarization.binarizeTree(tree);
-			annotationTrees.add(AnnotationTreeNode.getInstance(tree, treeBank.getNonterminalTable()));
+			treeBank.addTree(sentences[i], addParentLabel);
 		}
-		gExtractor.treeBank = treeBank;
-		gExtractor.initGrammar(1);
-		Grammar g = gExtractor.getGrammar(1, 0.5, 50);
+		GrammarExtractor gExtractor = new GrammarExtractor(treeBank);
+		Grammar g = gExtractor.getGrammar(1);
 
 		try
 		{

--- a/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/TreeUtilTest.java
+++ b/nlp4han-constituent/src/test/java/com/lc/nlp4han/constituent/unlex/TreeUtilTest.java
@@ -17,7 +17,6 @@ public class TreeUtilTest
 		String expression = "(Root(frag(frag(NN 自然)(NN 语言))))";
 		TreeNode tree = BracketExpUtil.generateTree(expression);
 		TreeUtil.removeL2LRule(tree);
-		System.out.println("\n" + TreeNode.printTree(tree, 0));
 	}
 
 	@Test
@@ -26,7 +25,6 @@ public class TreeUtilTest
 		String expression = "(ROOT(IP(NP (PN i))(VP (VV like)(NP (DT the) (NN book)))))";
 		TreeNode tree = BracketExpUtil.generateTree(expression);
 		TreeUtil.addParentLabel(tree);
-		System.out.println("\n" + TreeNode.printTree(tree, 0));
 	}
 
 	@Test
@@ -36,6 +34,5 @@ public class TreeUtilTest
 		TreeNode tree = BracketExpUtil.generateTree(expression);
 		TreeUtil.addParentLabel(tree);
 		TreeUtil.removeParentLabel(tree);
-		System.out.println("\n" + TreeNode.printTree(tree, 0));
 	}
 }


### PR DESCRIPTION
1.修改了UnlexEvaTool名称；2.增加了父节点标注的交叉验证；3.修改了单元测试代码；4.现在TreeBank通过不断加入树构建；添加了缩放工具、将树的似然率修改为log似然率。
GrammarExtratorTool中设置参数addParentLabel = true，SMCycle = 0。即可得到带父节点标注的语法。
